### PR TITLE
Use Makefile for docs build in Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,13 +27,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Create virtual environment
+        run: make venv
+
       - name: Install docs dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r docs/requirements.txt
+          ./.venv/bin/pip install --upgrade pip
+          ./.venv/bin/pip install -r docs/requirements.txt
 
       - name: Build site
-        run: mkdocs build --strict
+        run: make docs-build
 
       - name: Configure Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Pages workflow builds documentation using the repository Makefile targets and the same virtual environment used locally.
- Install documentation dependencies into the project-managed `.venv` to keep the build environment consistent with local development.

### Description
- Add a `Create virtual environment` step that runs `make venv` in the Pages build job.
- Install docs dependencies via `./.venv/bin/pip install -r docs/requirements.txt` instead of the global `pip`.
- Replace the direct `mkdocs build --strict` call with `make docs-build` so the Makefile controls the build behavior.

### Testing
- No automated tests were run for this change because it only modifies the CI workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dbe96e77083209620347f708ac35d)