### PR TITLE
Docs: update artifact contract to outputs/<run_name>/, refresh overview, and add dark-mode toggle

### DIFF
--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -3,14 +3,16 @@
 Each run writes a consistent set of artifacts under:
 
 ```
-runs/<run_fingerprint>/
+outputs/<run_name>/
 ```
+
+For example, `output_dir: "outputs/demo_run"` yields `outputs/demo_run/results.csv`.
 
 ## Required outputs
 
 | File | Purpose |
 | --- | --- |
-| `features.parquet` | Tabular features generated for each sampled cell. |
+| `results.csv` | Tabular features and scores generated per sampled cell. |
 | `manifest.json` | Run metadata including configuration and input fingerprints. |
 | `report.json` | Summary statistics and model outputs for quick inspection. |
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,22 +1,80 @@
-# Architecture Overview
+# TerraFlow Overview
 
-TerraFlow v0.1 is intentionally simple: it ingests local geospatial datasets, runs a deterministic suitability
-pipeline, and writes outputs to a structured run directory. The core focus is **reproducibility** rather
-than an exhaustive modeling toolkit.
+TerraFlow is a reproducible geospatial modeling framework that turns local geospatial inputs into
+traceable, analysis-ready artifacts. The core pipeline focuses on deterministic processing of
+region-of-interest (ROI) geographies and raster stacks so that every run can be recreated and
+audited with confidence.
 
-## High-level flow
+## Inputs (v0.1)
 
-1. **Ingest** local raster and climate CSV inputs.
-2. **Clip** raster data to the requested region of interest.
-3. **Aggregate** climate metrics for the run.
-4. **Score** each sampled cell and create a results table.
-5. **Persist** outputs under a run-specific directory.
+- YAML configuration file.
+- ROI boundary defined in the YAML (bbox in v0.1 examples).
+- Local GeoTIFF raster input (for example, `data/usda_cdl.tif`).
+- Local climate CSV input (for example, `data/demo_climate.csv`).
 
-## Design principles
+## Outputs (v0.1 stable contract)
 
-- **Deterministic runs:** the same inputs and configuration yield the same run fingerprint and outputs.
-- **Clear boundaries:** ingestion and core modeling are separate modules with minimal coupling.
-- **Local-first:** v0.1 only loads datasets from local files (no remote fetches).
-- **Traceable artifacts:** run outputs have a defined, inspectable contract.
+All outputs are written under a deterministic run directory:
 
-For boundary details and run identity rules, see the following pages.
+```
+outputs/<run_name>/
+```
+
+- `results.csv`: extracted features and scores per sampled cell.
+- `manifest.json`: canonicalized inputs, file fingerprints, and provenance metadata.
+- `report.json`: QA summaries, timing, and coverage statistics.
+
+For example, a demo configuration that sets `output_dir: "outputs/demo_run"` will emit
+`outputs/demo_run/results.csv` alongside the manifest and report.
+
+## Canonical pipeline
+
+```mermaid
+flowchart TD
+  A[YAML config] --> C[terraflow.core]
+  B[ROI bbox] --> C
+  D[Local GeoTIFF raster] --> E[Dataset resolution layer (future)]
+  F[Local climate CSV] --> E
+  E --> C
+  C --> G[Compute run_fingerprint]
+  G --> H[Raster/vector processing\nCRS align • mask/clip • zonal stats]
+  H --> I[outputs/<run_name>/results.csv]
+  H --> J[outputs/<run_name>/manifest.json]
+  H --> K[outputs/<run_name>/report.json]
+```
+
+## How a run works
+
+1. **Load configuration** and normalize relevant settings.
+2. **Load and normalize the ROI** geometry for consistent spatial operations.
+3. **Resolve local datasets** via the dataset resolution layer (future) for raster and climate sources.
+4. **Compute the run_fingerprint** deterministically.
+5. **Execute raster/vector processing** for clipping, masking, and zonal statistics.
+6. **Write outputs** with timings and QA summaries for inspection.
+
+## Reproducibility
+
+The `run_fingerprint` is a base64-url-safe hash derived from canonicalized configuration, a
+stable ROI geometry hash, and fingerprints of the input files. This makes each run immutable
+and comparable. The `manifest.json` captures the canonical inputs and file fingerprints, while
+`report.json` records timing and QA summaries that explain what the run produced.
+
+## Geospatial correctness
+
+TerraFlow treats geospatial correctness as a first-class concern:
+
+- **CRS strategy:** ROI geometries are normalized and aligned to raster CRS expectations before
+  extraction begins.
+- **Clipping and masking:** raster data is clipped and masked to the ROI boundary to avoid
+  leaking pixels outside the target geography.
+- **NoData propagation:** nodata values are preserved through processing to prevent false
+  statistics.
+- **Coverage checks:** `report.json` summarizes nodata ratios and coverage statistics so runs can
+  be audited for spatial completeness.
+
+## Non-goals (v0.1)
+
+- Remote dataset downloads or cloud-hosted sources.
+- A hosted platform, workflow engine, or orchestration service.
+- A GUI-first GIS tool.
+- A general-purpose raster processing library.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,21 @@
 # TerraFlow Documentation
 
-TerraFlow is a reproducible geospatial modeling framework designed for agricultural and environmental analysis.
-This site covers the architecture, configuration schema, CLI workflow, and API reference for the v0.1 pipeline.
+TerraFlow is a reproducible geospatial modeling framework for agricultural and environmental analysis.
+Start with the [TerraFlow Overview](architecture/overview.md) to understand the core pipeline and contracts.
 
-## What TerraFlow does
+## v0.1 scope
 
-- Loads raster and climate inputs from local files.
-- Clips data to a region of interest (ROI).
-- Computes a simple suitability score and emits tabular outputs.
-- Records deterministic run metadata and artifacts for reproducibility.
+TerraFlow v0.1 is local-first and assumes:
+
+- ROI boundaries defined in YAML (bbox in v0.1 examples).
+- Local GeoTIFF raster inputs (for example, `data/usda_cdl.tif`).
+- Local climate CSV inputs (for example, `data/demo_climate.csv`).
 
 ## Quickstart
-
-1. Create a virtual environment and install the package plus docs dependencies.
-2. Preview the documentation locally:
 
 ```bash
 mkdocs serve
 ```
-
-3. Build the site with strict validation:
 
 ```bash
 mkdocs build --strict
@@ -27,9 +23,7 @@ mkdocs build --strict
 
 ## Documentation map
 
-- **Architecture** explains boundaries, run identity, and artifact contracts.
+- **Architecture** covers TerraFlow overview, boundaries, run identity, and artifact contracts.
 - **Config** describes the YAML schema and provides examples.
-- **CLI** covers running the pipeline from the command line.
-- **API Reference** is generated from the Python sources via `mkdocstrings`.
-
-If you're new to TerraFlow, start with the architecture overview and the configuration schema.
+- **CLI** explains how to run TerraFlow.
+- **API Reference** documents the core modules.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,17 @@ repo_url: https://github.com/gmarupilla/AgroTerraFlow
 
 theme:
   name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   features:
     - navigation.tabs
     - navigation.sections
@@ -35,7 +46,7 @@ plugins:
 nav:
   - Home: index.md
   - Architecture:
-      - Overview: architecture/overview.md
+      - TerraFlow Overview: architecture/overview.md
       - Boundaries: architecture/boundaries.md
       - Run Identity: architecture/run-identity.md
       - Artifact Contract: architecture/artifacts.md


### PR DESCRIPTION
### Motivation

- Clarify the stable artifact contract and example output paths to match the ingest requirement and practical downstream usage.
- Make the TerraFlow v0.1 scope and inputs explicit for local-only ingest (local GeoTIFF + local climate CSV) so docs reflect real ingestion expectations.
- Improve documentation usability by surfacing the high-level overview and enabling a Material theme light/dark toggle for readers.

### Description

- Replace the run output layout in `docs/architecture/artifacts.md` from `runs/<run_fingerprint>/` to `outputs/<run_name>/`, change `features.parquet` to `results.csv`, and add the example `outputs/demo_run/results.csv` path.
- Rewrite `docs/architecture/overview.md` as the canonical "TerraFlow Overview" with explicit v0.1 inputs (local GeoTIFF and climate CSV examples), updated outputs contract (`outputs/<run_name>/`), a Mermaid pipeline including the future dataset resolution layer, and reproducibility/geospatial correctness sections.
- Update `docs/index.md` to point readers to the TerraFlow Overview and list the v0.1 scope and example input types.
- Modify `mkdocs.yml` to add a Material theme `palette` with a light/dark toggle and rename the Architecture nav entry to "TerraFlow Overview".

### Testing

- No automated test suite was executed for these docs-only changes.
- An attempted `mkdocs build --strict` could not be completed in this environment because `mkdocs` is not installed, so site build validation was not performed.
- The documentation files were updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc351974883209a6d5b75aada4757)