### PR TITLE
Enable Mermaid rendering in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,11 @@ theme:
 
 markdown_extensions:
   - admonition
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
   - pymdownx.tabbed
   - pymdownx.highlight
@@ -35,6 +39,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - mermaid2
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
### Motivation
- Fix Mermaid diagrams rendering as plain code blocks by enabling proper Mermaid processing in the docs build.
- Keep the change minimal and compatible with the Material theme and GitHub Pages while preserving dark mode support.

### Description
- Added the `mermaid2` plugin to `plugins` in `mkdocs.yml` so MkDocs processes Mermaid diagrams at build time.
- Configured `pymdownx.superfences` with a `mermaid` `custom_fences` entry in `mkdocs.yml` so triple-backtick fences labeled `mermaid` are emitted as Mermaid markup instead of code blocks.
- No additional plugins or custom JavaScript were introduced, keeping the fix small and theme-compatible.

### Testing
- No automated tests were run for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcbad206c832080460ba4abd4e7b5)