### PR TITLE
Add mkdocs-mermaid2-plugin to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,5 @@ mkdocstrings[python]>=0.24
 mkdocs-gen-files>=0.5
 mkdocs-literate-nav>=0.6
 mkdocs-section-index>=0.3
+mkdocs-mermaid2-plugin>=1.1.1
 pymdown-extensions>=10


### PR DESCRIPTION
### Motivation
- Ensure the `mermaid2` MkDocs plugin declared in `mkdocs.yml` resolves during documentation builds by providing the plugin dependency in the docs requirements.

### Description
- Add `mkdocs-mermaid2-plugin>=1.1.1` to `docs/requirements.txt` so the `mermaid2` plugin is installed for MkDocs site builds.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dce5b4710832096e8653e32a218f9)