### PR TITLE
Fix mermaid diagram output paths

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -38,9 +38,9 @@ flowchart TD
   E --> C
   C --> G[Compute run_fingerprint]
   G --> H[Raster/vector processing\nCRS align • mask/clip • zonal stats]
-  H --> I[outputs/<run_name>/results.csv]
-  H --> J[outputs/<run_name>/manifest.json]
-  H --> K[outputs/<run_name>/report.json]
+  H --> I[outputs/run_name/results.csv]
+  H --> J[outputs/run_name/manifest.json]
+  H --> K[outputs/run_name/report.json]
 ```
 
 ## How a run works


### PR DESCRIPTION
### Motivation
- Fix a syntax error in the `mermaid` diagram in `docs/architecture/overview.md` caused by angle brackets in node labels which produce invalid Mermaid text.

### Description
- Replace `outputs/<run_name>/results.csv`, `outputs/<run_name>/manifest.json`, and `outputs/<run_name>/report.json` with `outputs/run_name/...` in the `mermaid` flowchart in `docs/architecture/overview.md` to remove the problematic `<` and `>` characters.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3b3b940883208125f14500d29256)