### PR TITLE
Refactor CLI to Typer with `run` subcommand and ROI/output overrides

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,8 @@ from terraflow.config import load_config
 
 
 def test_load_config_tmp(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -25,7 +26,8 @@ def test_load_config_tmp(tmp_path: Path):
           w_v: 0.4
           w_t: 0.3
           w_r: 0.3
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,7 +11,8 @@ def test_run_pipeline_with_synthetic_data(
 ):
     out_dir = tmp_path / "outputs"
 
-    cfg_content = textwrap.dedent(f"""
+    cfg_content = textwrap.dedent(
+        f"""
         raster_path: "{synthetic_raster}"
         climate_csv: "{synthetic_climate_csv}"
         output_dir: "{out_dir}"
@@ -35,7 +36,8 @@ def test_run_pipeline_with_synthetic_data(
           w_r: 0.3
 
         max_cells: 10
-        """)
+        """
+    )
 
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Modernize the CLI by replacing the existing argparse-based entrypoint with Typer while preserving existing behavior and flags.
- Allow CLI-driven overrides for ROI GeoJSON and output directory without changing pipeline semantics or config format.

### Description
- Replace `terraflow/cli.py` to provide a Typer app with a `run` command that preserves `--config`/`-c` semantics and adds optional `--roi` and `--out-dir` overrides and a `--version` flag, with input validation using `pathlib.Path` and Typer's `BadParameter` errors.
- Add `load_roi_geojson` to `terraflow/config.py` to convert a GeoJSON to a bounding-box `ROI` using `geopandas`, and keep YAML config parsing via `load_config` unchanged.
- Introduce `run_pipeline_with_overrides` in `terraflow/pipeline.py` which applies CLI overrides (`roi` and `output_dir`) to a validated `PipelineConfig` and delegates to the existing pipeline implementation without changing business logic, determinism, or fingerprinting.
- Update packaging and docs: add `typer` to `pyproject.toml` and register the console script `terraflow = "terraflow.cli:app"`, update `README.md`, `docs/cli/usage.md`, `Makefile`, and `Dockerfile` to use the `run` subcommand and updated entrypoint.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed4ca1b748320bfda91fc7ed0a865)