### PR TITLE
Switch project tooling and CI to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Ensure make is available
         run: |
           sudo apt-get update

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,13 +27,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Create virtual environment
         run: make venv
-
-      - name: Install docs dependencies
-        run: |
-          ./.venv/bin/pip install --upgrade pip
-          ./.venv/bin/pip install -r docs/requirements.txt
 
       - name: Build site
         run: make docs-build

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,10 +18,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install build backend
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
+          uv pip install --system --upgrade build
 
       - name: Build package
         run: python -m build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.11-slim
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PATH="/root/.cargo/bin:${PATH}"
 
 # System dependencies for rasterio / GDAL
 RUN apt-get update && \
@@ -13,12 +14,13 @@ RUN apt-get update && \
         build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt ./
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+COPY pyproject.toml README.md ./
+COPY terraflow ./terraflow
+RUN uv pip install --system .
 
 # Copy library code and example config
-COPY terraflow ./terraflow
 COPY examples ./examples
 
 # Default entrypoint: run CLI; user passes --config or uses default CMD

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 PYTHON = .venv/bin/python
-PIP = .venv/bin/pip
+UV = uv
 RUFF = .venv/bin/ruff
 BLACK = .venv/bin/black
 
@@ -26,14 +26,13 @@ help:
 # ---------------------------
 
 venv:
-	python3 -m venv .venv
-	$(PIP) install --upgrade pip
+	$(UV) venv .venv
 
 install: venv
-	$(PIP) install -e .
+	$(UV) pip install --python $(PYTHON) -e .
 
 dev: venv
-	$(PIP) install -e ".[dev]"
+	$(UV) pip install --python $(PYTHON) -e ".[dev]"
 
 # ---------------------------
 # Testing & Running
@@ -50,7 +49,7 @@ run-demo:
 # ---------------------------
 
 build:
-	$(PIP) install --upgrade build
+	$(UV) pip install --python $(PYTHON) --upgrade build
 	$(PYTHON) -m build
 
 clean:
@@ -80,5 +79,5 @@ docs-serve:
 	$(PYTHON) -m mkdocs serve
 
 docs-build:
-	$(PIP) install -r docs/requirements.txt
+	$(UV) pip install --python $(PYTHON) -r docs/requirements.txt
 	$(PYTHON) -m mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use TerraFlow to build, test, and publish reproducible agricultural analytics pi
 ## 🚀 Features
 
 * Modern Python package (`pyproject.toml`, PEP 621)
-* Fully pip-installable (`pip install terraflow-agro`)
+* Fully uv-installable (`uv pip install terraflow-agro`)
 * Reproducible CLI interface (`terraflow run --config <file>`)
 * Pydantic v2 configuration models
 * Extensible workflow architecture
@@ -36,7 +36,7 @@ Use TerraFlow to build, test, and publish reproducible agricultural analytics pi
 ## **Option 1: Install from PyPI (Recommended)**
 
 ```bash
-pip install terraflow-agro
+uv pip install terraflow-agro
 ```
 
 Verify installation:
@@ -65,8 +65,8 @@ make dev
 
 This runs:
 
-* `python -m venv .venv`
-* `pip install -e ".[dev]"`
+* `uv venv .venv`
+* `uv pip install --python .venv/bin/python -e ".[dev]"`
   (Using only `pyproject.toml` — no requirements.txt)
 
 ---
@@ -145,7 +145,7 @@ outputs/
 Install the docs dependencies and serve the site:
 
 ```bash
-pip install -r docs/requirements.txt
+uv pip install -r docs/requirements.txt
 mkdocs serve
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ make lint
 Install docs dependencies and run a local preview:
 
 ```bash
-pip install -r docs/requirements.txt
+uv pip install -r docs/requirements.txt
 mkdocs serve
 ```
 


### PR DESCRIPTION
### Motivation
- Replace `pip`-centric workflows with `uv` as the project package manager and installer across tooling, docs, CI, and Docker to standardize dependency management.
- Ensure build and docs jobs in CI and publishing flows can use `uv`-driven installs so pipelines remain consistent and reproducible.

### Description
- Updated `Makefile` to introduce `UV = uv` and replace `pip` calls with `uv` equivalents for `venv`, `install`, `dev`, `build`, and `docs-build` targets.
- Updated GitHub Actions (`.github/workflows/ci.yml`, `docs.yml`, `publish-pypi.yml`) to install `uv` (`astral-sh/setup-uv@v3`) and to use `uv` for installing build dependencies in the publish workflow.
- Modified `Dockerfile` to install `uv`, copy `pyproject.toml`/`README.md`, and install the package via `uv pip install --system .` instead of relying on a `requirements.txt` file.
- Updated documentation and contributing guides (`README.md`, `docs/contributing.md`) to show `uv`-based commands for local setup and docs installation.

### Testing
- No automated tests were executed as part of this change; CI workflow files were updated to use `uv` and will run on the next push/PR to validate the pipeline end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697167d214dc8320a1caf6ad0aa6d7e2)