### PR TITLE
fix(ci): grant write permissions to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- `pull-requests: write` and `issues: write` so the `claude[bot]` can post inline review comments
- Previously set to `read`, causing 7 permission denials per run and silently dropping all review output

## Why this must land on main first
The `claude-code-action` validates that the workflow file on the PR branch matches `main` exactly before exchanging OIDC tokens. Without this merged to `main`, the review job will keep failing with a 401 on every PR.