### PR TITLE
docs: add CONTRIBUTING.md, project scope, and maintenance sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to TerraFlow
+
+TerraFlow is a solo-maintained research software project. Contributions are welcome
+but should align with the project's scope: reproducible geospatial pipelines for
+agricultural modeling.
+
+## Dev Setup
+
+```bash
+git clone https://github.com/gmarupilla/AgroTerraFlow
+cd AgroTerraFlow
+pip install -e ".[dev]"
+pytest
+```
+
+The test suite requires no external data — synthetic rasters are generated automatically.
+To run with coverage: `pytest --cov=terraflow --cov-report=term-missing`
+
+## Code Style
+
+- Formatter: `black` (line length 88)
+- Linter: `ruff`
+- Type hints: required on all public functions
+- Run both before opening a PR: `ruff check . && black --check .`
+
+## Pull Requests
+
+- Keep PRs small and focused on a single concern
+- All new behavior must include tests
+- Update `CHANGELOG.md` under `[Unreleased]`
+- CI must pass before review
+
+## Issues
+
+Use issues to:
+- Report bugs with a reproducible config + stack trace
+- Propose targeted improvements with clear motivation
+- Discuss changes before writing code for non-trivial work
+
+Feature requests are evaluated against project scope (see README). Requests that
+require significant maintenance burden or diverge from the core pipeline design
+may be declined.
+
+## Scope
+
+TerraFlow is not a general geospatial framework. Before contributing, read the
+"Project Scope" section in the README to avoid building something that won't be merged.
+
+## Questions
+
+Open a GitHub issue with the `question` label. Response is best-effort.

--- a/README.md
+++ b/README.md
@@ -108,9 +108,38 @@ Core modules: `cli`, `config`, `climate`, `geo`, `ingest`, `model`, `pipeline`, 
 
 Key design decisions are documented in Architecture Decision Records under `docs/architecture/`.
 
+## Project Scope
+
+TerraFlow is a reproducible pipeline for geospatial agricultural modeling. It
+handles raster ingestion, ROI clipping, climate interpolation, suitability
+scoring, and deterministic artifact generation.
+
+**In scope:**
+- Configuration-driven pipeline execution (YAML → Parquet + provenance artifacts)
+- Spatial interpolation of point climate observations (linear, kriging, IDW)
+- Per-cell suitability scoring with uncertainty quantification (Monte Carlo)
+- Deterministic run fingerprinting and artifact caching
+
+**Out of scope:**
+- Real-time data ingestion or streaming workflows
+- General-purpose raster analysis (use `rioxarray` or `rasterstats` instead)
+- Cloud-scale distributed processing (no Dask/Spark integration planned)
+- Web application or GUI layer
+
+## Maintenance & Support
+
+TerraFlow is actively maintained. Bug fixes are prioritized; the test suite and
+CI pipeline are kept green on every commit.
+
+Feature requests are evaluated against project scope — open an issue to discuss
+before building. Not all requests will be accepted.
+
+Support is provided on a best-effort basis via [GitHub Issues](https://github.com/gmarupilla/AgroTerraFlow/issues).
+Response time is typically within a week. There is no paid support tier.
+
 ## Contributing
 
-See [docs/contributing.md](docs/contributing.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Citation
 


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` with dev setup, code style, PR guidelines, and issue usage guidance
- Adds **Project Scope** section to README — defines what TerraFlow is and is not
- Adds **Maintenance & Support** section to README — states active maintenance and support expectations
- Updates `## Contributing` link to point to root `CONTRIBUTING.md`

## Why

Prepares the repo for JOSS submission. `CONTRIBUTING.md` is a checklist item in JOSS reviewer criteria. The scope and support sections provide clarity for external users and signal a mature, maintained project.