### PR TITLE
feat(packaging): Homebrew tap support with automated formula updates

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,66 @@
+name: Publish to Homebrew Tap
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish-homebrew:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for tarball
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          URL="https://github.com/gmarupilla/AgroTerraFlow/archive/refs/tags/${TAG}.tar.gz"
+          for i in $(seq 1 12); do
+            STATUS=$(curl -sLo /dev/null -w "%{http_code}" "${URL}")
+            [ "${STATUS}" = "200" ] && break
+            echo "Attempt ${i}: HTTP ${STATUS}, retrying in 10s..."
+            sleep 10
+          done
+          [ "${STATUS}" = "200" ] || { echo "Tarball unavailable after 2 minutes"; exit 1; }
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          SHA=$(curl -sL "https://github.com/gmarupilla/AgroTerraFlow/archive/refs/tags/${TAG}.tar.gz" | sha256sum | awk '{print $1}')
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "SHA256: ${SHA}"
+
+      - name: Clone tap repo
+        run: |
+          git clone "https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/gmarupilla/homebrew-terraflow.git" tap-repo
+
+      - name: Update formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA="${{ steps.sha.outputs.sha256 }}"
+          FORMULA="tap-repo/Formula/terraflow.rb"
+          sed -i "s|archive/refs/tags/v[0-9.]*\.tar\.gz|archive/refs/tags/v${VERSION}.tar.gz|" "${FORMULA}"
+          sed -i 's|sha256 "[^"]*"|sha256 "'"${SHA}"'"|' "${FORMULA}"
+          echo "Updated formula:"
+          cat "${FORMULA}"
+
+      - name: Commit and push
+        run: |
+          cd tap-repo
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/terraflow.rb
+          git diff --staged --quiet && echo "No changes to commit." && exit 0
+          git commit -m "terraflow ${{ steps.version.outputs.version }}"
+          git push origin main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   seeded cell-set stability, score stability, fingerprint presence, and fingerprint
   stability across independent runs.
 - `synthetic_climate_csv_dense` pytest fixture (8 stations) for kriging tests.
+- **Homebrew tap**: `brew tap gmarupilla/terraflow && brew install terraflow` for macOS — handles GDAL and PROJ system-library installation automatically. Formula at `packaging/homebrew/Formula/terraflow.rb`.
+- `publish-homebrew.yml`: auto-updates `gmarupilla/homebrew-terraflow` formula (url + sha256) on every `v*.*.*` tag push. ADR-006 documents the tap-vs-Core decision.
 
 ### Fixed
 - **Reproducibility**: cell sampling in `run_pipeline` now uses a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,128 @@ Per project conventions, every PR must:
 - Add a Jupyter notebook example in `notebooks/` and register it in `docs/notebooks/`
 - Update `mkdocs.yml` nav if new pages added
 - Add an entry to `CHANGELOG.md` under `[Unreleased]`
+
+## Packaging & Release
+
+### Versioning
+
+Version is declared in **two places** — both must be updated together:
+- `pyproject.toml` line `version = "X.Y.Z"`
+- `terraflow/__init__.py` `__version__ = "X.Y.Z"`
+
+Project follows [Semantic Versioning](https://semver.org). Current version: `0.2.1`.
+
+### Release steps
+
+```bash
+# 1. Update version in both files
+# 2. Update CHANGELOG.md: move [Unreleased] items under a new [X.Y.Z] heading with date
+# 3. Commit the version bump
+git commit -m "chore: bump version to vX.Y.Z"
+# 4. Tag and push — this fires both publish workflows
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+### PyPI (`publish-pypi.yml`)
+
+Triggers on `v*.*.*` tag push. Builds sdist + wheel, attests provenance, and publishes
+to PyPI via `pypa/gh-action-pypi-publish`. Requires secret: `PYPI_API_TOKEN`.
+
+Package name on PyPI: `terraflow-agro`. Install: `pip install terraflow-agro`.
+
+### Homebrew tap (`publish-homebrew.yml`)
+
+Triggers on the same `v*.*.*` tag, runs in parallel with the PyPI workflow.
+Fetches the GitHub archive tarball, computes its SHA-256, then patches
+`Formula/terraflow.rb` in `gmarupilla/homebrew-terraflow` (separate GitHub repo)
+and pushes the update.
+
+Requires secret: `HOMEBREW_TAP_TOKEN` (GitHub PAT with `repo` write scope on
+`gmarupilla/homebrew-terraflow`).
+
+Formula source of truth: `packaging/homebrew/Formula/terraflow.rb`  
+Local helper (dev use): `packaging/homebrew/update_sha.sh <version>` — cross-platform
+(works on macOS BSD sed and Linux GNU sed).
+
+User install: `brew tap gmarupilla/terraflow && brew install terraflow`
+
+### Optional extras
+
+| Extra | Packages | Install |
+|-------|----------|---------|
+| `[h3]` | `h3>=4.0,<5` | `pip install terraflow-agro[h3]` |
+| `[viz]` | `plotly` | `pip install terraflow-agro[viz]` |
+
+## CI/CD Overview
+
+All workflows live in `.github/workflows/`:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `ci.yml` | push/PR to main | Tests (Py 3.10–3.12), lint, mypy, coverage, smoke tests, Docker E2E |
+| `publish-pypi.yml` | `v*.*.*` tag | Build + publish to PyPI with provenance attestation |
+| `publish-homebrew.yml` | `v*.*.*` tag | Auto-update Homebrew tap formula |
+| `docs.yml` | push to main | Build + deploy MkDocs to GitHub Pages |
+| `docs-preview.yml` | PR | Build docs preview |
+| `quality.yml` | push/PR | Additional code quality checks |
+| `claude.yml` | PR | AI-assisted review (skips bot authors) |
+| `security.yml` | schedule/push | Dependency vulnerability scan |
+| `license-check.yml` | push/PR | Verify dependency licenses |
+| `sonarcloud.yml` | push/PR | SonarCloud static analysis |
+| `manuscript.yml` | push/PR | Build JOSS paper PDF |
+
+Coverage floor: 85% (`fail_under = 85` in `pyproject.toml`). Codecov tracks trends.
+
+## Documentation Structure
+
+MkDocs with Material theme, deployed to `https://terraflow.marupilla.dev`.
+
+```
+docs/
+├── index.md                  # Home / landing page
+├── quickstart.md             # 10-minute getting started
+├── field-guide.md            # Practical usage guide
+├── DEVELOPMENT.md            # Dev setup, release checklist
+├── ROADMAP.md                # Feature roadmap
+├── contributing.md           # Contribution guidelines
+├── architecture/
+│   ├── overview.md           # System architecture overview
+│   ├── adr-001–006.md        # Architecture Decision Records
+│   ├── boundaries.md         # System boundaries
+│   ├── run-identity.md       # Run fingerprinting design
+│   └── artifacts.md          # Output artifact contract
+├── config/
+│   ├── schema.md             # Full YAML config reference
+│   └── examples.md           # Annotated config examples
+├── cli/
+│   └── usage.md              # CLI subcommand reference
+├── install/
+│   └── homebrew.md           # Homebrew install guide (macOS)
+├── guides/
+│   └── h3-export.md          # H3 hexagonal export guide
+├── api/
+│   ├── core.md               # terraflow.core autodoc
+│   ├── ingest.md             # terraflow.ingest autodoc
+│   └── climate.md            # terraflow.climate autodoc
+└── notebooks/                # Rendered Jupyter notebooks
+    ├── terraflow_v0_2_0_comprehensive_test.ipynb
+    ├── kriging_uncertainty_demo.ipynb
+    ├── 02_sensitivity_analysis.ipynb
+    ├── 03_model_validation.ipynb
+    └── 04_h3_export.ipynb
+```
+
+When adding a new page: create the `.md` file, add it to `mkdocs.yml` nav, and
+(if it's a guide/feature) add a notebook in `notebooks/` registered under the
+`Notebooks:` nav section.
+
+## Key External Repos & Services
+
+| Resource | URL / location |
+|----------|---------------|
+| Homebrew tap | `github.com/gmarupilla/homebrew-terraflow` |
+| PyPI package | `pypi.org/project/terraflow-agro` |
+| Docs site | `terraflow.marupilla.dev` |
+| SonarCloud | project key `gmarupilla_AgroTerraFlow` |
+| Codecov | `codecov.io/gh/gmarupilla/AgroTerraFlow` |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Publish to PyPI](https://github.com/gmarupilla/AgroTerraFlow/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/gmarupilla/AgroTerraFlow/actions/workflows/publish-pypi.yml)
 [![Build JOSS Manuscript](https://github.com/gmarupilla/AgroTerraFlow/actions/workflows/manuscript.yml/badge.svg)](https://github.com/gmarupilla/AgroTerraFlow/actions/workflows/manuscript.yml)
 [![PyPI](https://img.shields.io/pypi/v/terraflow-agro.svg)](https://pypi.org/project/terraflow-agro/)
+[![Homebrew Tap](https://img.shields.io/badge/brew-gmarupilla%2Fterraflow-orange.svg)](https://github.com/gmarupilla/homebrew-terraflow)
 [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=gmarupilla_AgroTerraFlow&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=gmarupilla_AgroTerraFlow)
 [![Codecov](https://codecov.io/gh/gmarupilla/AgroTerraFlow/branch/main/graph/badge.svg)](https://codecov.io/gh/gmarupilla/AgroTerraFlow)
@@ -18,6 +19,15 @@ TerraFlow is a reproducible, config-driven geospatial workflow for agricultural 
 
 ## Installation
 
+**macOS (Homebrew)** — handles GDAL and PROJ automatically:
+
+```bash
+brew tap gmarupilla/terraflow
+brew install terraflow
+```
+
+**pip / uv:**
+
 ```bash
 uv pip install terraflow-agro
 # or
@@ -29,6 +39,8 @@ For kriging-based interpolation:
 ```bash
 pip install terraflow-agro pykrige
 ```
+
+See [Homebrew install docs](https://terraflow.marupilla.dev/install/homebrew/) for update/uninstall instructions and troubleshooting.
 
 ## Quickstart
 

--- a/docs/architecture/adr-006-homebrew-distribution.md
+++ b/docs/architecture/adr-006-homebrew-distribution.md
@@ -1,0 +1,95 @@
+# ADR-006: Homebrew Distribution via Custom Tap
+
+**Status:** Accepted  
+**Date:** 2026-04-11
+
+## Context
+
+TerraFlow is a Python CLI tool that depends on rasterio and pyproj, both of which
+require system-level GDAL and PROJ shared libraries. `pip install terraflow-agro`
+does not install these system libraries, leaving macOS users to resolve them manually
+(typically via Homebrew or conda anyway). This creates unnecessary friction for the
+most common macOS install path.
+
+Homebrew is the de facto package manager for macOS developer tools. A Homebrew
+formula can declare system-level dependencies (`gdal`, `proj`) and have them
+installed automatically as part of `brew install`.
+
+Two distribution options were considered:
+
+| Option | Description |
+|--------|-------------|
+| **Homebrew Core** | Submit a formula to `homebrew/homebrew-core`; accessible via `brew install terraflow` without a tap |
+| **Custom tap** | Publish a personal tap at `gmarupilla/homebrew-terraflow`; accessible via `brew tap gmarupilla/terraflow && brew install terraflow` |
+
+## Decision
+
+Use a **custom Homebrew tap** (`gmarupilla/homebrew-terraflow`).
+
+## Rationale
+
+Homebrew Core submission requires:
+- ≥ 75 GitHub stars on the upstream repo (soft threshold)
+- Formula review by Homebrew maintainers (timeline unpredictable)
+- Ongoing compliance with Homebrew's audit rules and deprecation policy
+- Commitment to keep the formula passing `brew audit --strict` at all times
+
+A custom tap:
+- Ships immediately — no review queue
+- Can be automated end-to-end via CI (see `publish-homebrew.yml`)
+- Is appropriate for a research-grade scientific CLI at this stage of maturity
+- Can be promoted to Core later once the project has a larger install base
+
+## Formula Design
+
+```ruby
+class Terraflow < Formula
+  include Language::Python::Virtualenv
+  depends_on "python@3.12"
+  depends_on "proj"
+  depends_on "gdal"
+  def install
+    venv = virtualenv_create(libexec, "python3.12")
+    venv.pip_install buildpath
+    bin.install_symlink Dir["#{libexec}/bin/terraflow"]
+  end
+end
+```
+
+- `Language::Python::Virtualenv` isolates the formula's Python environment from the
+  user's system Python — no version conflicts.
+- `python@3.12` is pinned to the latest stable Python LTS available in Homebrew.
+  TerraFlow supports `>=3.10`; 3.12 is the current recommended target.
+- `proj` and `gdal` are declared as system deps so Homebrew resolves them before
+  `pip_install` attempts to build rasterio's C extensions.
+- The formula source of truth lives at `packaging/homebrew/Formula/terraflow.rb`
+  in the main repo and is pushed to `gmarupilla/homebrew-terraflow` on each release.
+
+## Automation
+
+`publish-homebrew.yml` (`.github/workflows/`) triggers on every `v*.*.*` tag push:
+
+1. Waits for the GitHub archive tarball to become available
+2. Computes its SHA-256 with `sha256sum`
+3. Clones `gmarupilla/homebrew-terraflow` using `HOMEBREW_TAP_TOKEN` (a GitHub PAT)
+4. Patches the formula's `url` and `sha256` fields with `sed`
+5. Commits and pushes to the tap repo
+
+This runs in parallel with `publish-pypi.yml` — neither depends on the other.
+
+## Consequences
+
+**Positive:**
+- macOS users get a one-command install (`brew tap` once, then `brew install`)
+- `brew upgrade terraflow` keeps them current without manual intervention
+- GDAL and PROJ are installed and linked automatically
+
+**Neutral:**
+- Users must run `brew tap gmarupilla/terraflow` once before installing (not required
+  for Core formulae, but universally understood by Homebrew users)
+- Optional extras (`[h3]`, `[viz]`) are not available via the formula; pip must be
+  used for those (documented in `docs/install/homebrew.md`)
+
+**Future:**
+- If the project reaches Homebrew Core eligibility, the formula at
+  `packaging/homebrew/Formula/terraflow.rb` is ready for submission with minimal changes

--- a/docs/install/homebrew.md
+++ b/docs/install/homebrew.md
@@ -1,0 +1,118 @@
+# Installing TerraFlow via Homebrew
+
+Homebrew is the recommended installation method for macOS users. It automatically
+handles the GDAL and PROJ system-library dependencies that rasterio and pyproj require.
+
+## Prerequisites
+
+- macOS 12 (Monterey) or later
+- [Homebrew](https://brew.sh) installed
+
+## Install
+
+```bash
+brew tap gmarupilla/terraflow
+brew install terraflow
+```
+
+The install step builds a Python 3.12 virtualenv in the Homebrew prefix and symlinks
+`terraflow` into your PATH. Expect a few minutes the first time — GDAL and PROJ may
+compile from source.
+
+## Verify
+
+```bash
+terraflow --help
+```
+
+You should see the usage message listing `run`, `sensitivity`, `validate`, and `export`.
+
+## Update
+
+```bash
+brew update
+brew upgrade terraflow
+```
+
+`brew update` fetches the latest formula from the tap; `brew upgrade` installs it.
+The tap formula is updated automatically on every tagged release via
+[`publish-homebrew.yml`](https://github.com/gmarupilla/AgroTerraFlow/blob/main/.github/workflows/publish-homebrew.yml).
+
+## Uninstall
+
+```bash
+brew uninstall terraflow
+brew untap gmarupilla/terraflow   # optional: remove the tap entirely
+```
+
+## Optional Extras
+
+The `[h3]` and `[viz]` extras are not available via the Homebrew formula because
+Homebrew virtualenvs are isolated. To use H3 export or Plotly visualizations,
+install via pip instead:
+
+```bash
+pip install "terraflow-agro[h3]"        # H3 hexagonal export
+pip install "terraflow-agro[viz]"       # Plotly visualization support
+pip install "terraflow-agro[h3,viz]"    # both
+```
+
+## Troubleshooting
+
+### GDAL environment variable conflicts
+
+If you see `CPLE_AppDefined` errors or rasterio emits `NotGeoreferencedWarning`,
+a stale environment variable may be overriding the Homebrew-managed GDAL. Unset it:
+
+```bash
+unset GDAL_DATA GDAL_DRIVER_PATH PROJ_LIB
+```
+
+If the issue persists, reinstall the formula:
+
+```bash
+brew reinstall terraflow
+```
+
+### PROJ database not found
+
+Symptom: `pyproj.exceptions.CRSError: PROJ: proj_create_from_database`
+
+Fix:
+
+```bash
+brew reinstall proj
+```
+
+If you have a system PROJ (conda, MacPorts) alongside the Homebrew one, check which
+takes precedence:
+
+```bash
+which proj   # should resolve to /opt/homebrew/bin/proj (Apple Silicon)
+             #                  or /usr/local/bin/proj (Intel)
+```
+
+### `brew install` fails during GDAL build
+
+On a fresh machine, the build can fail if Xcode Command Line Tools are incomplete:
+
+```bash
+xcode-select --install
+brew install gdal
+brew install terraflow
+```
+
+### Formula not found after `brew tap`
+
+```bash
+brew tap --repair gmarupilla/terraflow
+brew install terraflow
+```
+
+### Install the development HEAD
+
+```bash
+brew install --HEAD terraflow
+```
+
+Not recommended for production use — this clones the `main` branch directly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
       - ADR-002 BBox ROI: architecture/adr-002-bbox-roi.md
       - ADR-003 Climate Interpolation: architecture/adr-003-climate-interpolation.md
       - ADR-004 CRS Reprojection: architecture/adr-004-crs-reprojection.md
+      - ADR-006 Homebrew Distribution: architecture/adr-006-homebrew-distribution.md
       - Boundaries: architecture/boundaries.md
       - Run Identity: architecture/run-identity.md
       - Artifact Contract: architecture/artifacts.md
@@ -145,6 +146,8 @@ nav:
       - Examples: config/examples.md
   - CLI:
       - Usage: cli/usage.md
+  - Install:
+      - Homebrew (macOS): install/homebrew.md
   - Guides:
       - H3 Export: h3-export.md
   - API Reference:

--- a/packaging/homebrew/Formula/terraflow.rb
+++ b/packaging/homebrew/Formula/terraflow.rb
@@ -1,0 +1,24 @@
+class Terraflow < Formula
+  include Language::Python::Virtualenv
+
+  desc "Reproducible geospatial agricultural modeling pipeline"
+  homepage "https://github.com/gmarupilla/AgroTerraFlow"
+  url "https://github.com/gmarupilla/AgroTerraFlow/archive/refs/tags/v0.2.1.tar.gz"
+  sha256 "FILL_IN" # run: curl -sL <url> | shasum -a 256
+  license "MIT"
+  head "https://github.com/gmarupilla/AgroTerraFlow.git", branch: "main"
+
+  depends_on "python@3.12"
+  depends_on "proj"   # required by pyproj / rasterio
+  depends_on "gdal"   # required by rasterio
+
+  def install
+    venv = virtualenv_create(libexec, "python3.12")
+    venv.pip_install buildpath
+    bin.install_symlink Dir["#{libexec}/bin/terraflow"]
+  end
+
+  test do
+    assert_match "Usage: terraflow", shell_output("#{bin}/terraflow --help")
+  end
+end

--- a/packaging/homebrew/update_sha.sh
+++ b/packaging/homebrew/update_sha.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Usage: ./update_sha.sh <version>
+# Example: ./update_sha.sh 0.2.1
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version>}"
+URL="https://github.com/gmarupilla/AgroTerraFlow/archive/refs/tags/v${VERSION}.tar.gz"
+SHA=$(curl -sL "$URL" | shasum -a 256 | awk '{print $1}')
+
+FORMULA="$(dirname "$0")/Formula/terraflow.rb"
+
+# Cross-platform sed: GNU (Linux) uses -i without arg; BSD (macOS) requires -i ''
+if sed --version 2>/dev/null | grep -q GNU; then
+  sed -i "s|sha256 \"[^\"]*\"|sha256 \"${SHA}\"|" "$FORMULA"
+  sed -i "s|archive/refs/tags/v[0-9.]*\.tar\.gz|archive/refs/tags/v${VERSION}.tar.gz|" "$FORMULA"
+else
+  sed -i '' "s|sha256 \"[^\"]*\"|sha256 \"${SHA}\"|" "$FORMULA"
+  sed -i '' "s|archive/refs/tags/v[0-9.]*\.tar\.gz|archive/refs/tags/v${VERSION}.tar.gz|" "$FORMULA"
+fi
+
+echo "Updated $FORMULA with sha256 $SHA for v${VERSION}"


### PR DESCRIPTION
## Summary

- Add `publish-homebrew.yml` — auto-updates `gmarupilla/homebrew-terraflow` formula (url + sha256) on every `v*.*.*` tag push, runs in parallel with PyPI publish
- Add `packaging/homebrew/Formula/terraflow.rb` and `update_sha.sh` (cross-platform BSD/GNU sed)
- Add `docs/install/homebrew.md` — full install/update/uninstall/troubleshooting guide
- Add `docs/architecture/adr-006-homebrew-distribution.md` — documents tap-vs-Core decision
- Update `README.md`, `CHANGELOG.md`, `mkdocs.yml`, `CLAUDE.md` with Homebrew install and full end-to-end project context

## Usage after merge

```bash
brew tap gmarupilla/terraflow
brew install terraflow
```

Tap repo: https://github.com/gmarupilla/homebrew-terraflow  
Secret `HOMEBREW_TAP_TOKEN` already set in repo Actions secrets.

## Test plan

- [ ] Verify `make docs-serve` renders `Install > Homebrew (macOS)` page
- [ ] Tag a release (`git tag vX.Y.Z && git push origin main --tags`) and confirm `publish-homebrew.yml` patches the formula in the tap repo