### PR TITLE
fix(packaging): reorder depends_on for brew audit compliance

### DIFF
--- a/packaging/homebrew/Formula/terraflow.rb
+++ b/packaging/homebrew/Formula/terraflow.rb
@@ -8,9 +8,9 @@ class Terraflow < Formula
   license "MIT"
   head "https://github.com/gmarupilla/AgroTerraFlow.git", branch: "main"
 
+  depends_on "gdal"
+  depends_on "proj"
   depends_on "python@3.12"
-  depends_on "proj"   # required by pyproj / rasterio
-  depends_on "gdal"   # required by rasterio
 
   def install
     venv = virtualenv_create(libexec, "python3.12")


### PR DESCRIPTION
## Summary

- Reorder `depends_on` in `packaging/homebrew/Formula/terraflow.rb`: `gdal` and `proj` must precede `python@3.12` per Homebrew audit rules
- Formula now passes `brew audit --strict --new` with zero issues — prerequisite for Homebrew Core submission

## Test plan

- [x] `brew audit --strict --new gmarupilla/terraflow/terraflow` — 0 errors