### PR TITLE
chore: bump version to v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-04-12
+
 ### Added
 - **H3-indexed export** (`terraflow export --format h3 -c config.yml`): re-indexes suitability results by H3 hexagonal cell for interop with DeckGL, Kepler.gl, and h3pandas. Output written to `h3_resolution_N.parquet` in the run directory. New `to_h3()` function in `terraflow.export` and `run_export()` orchestrator. Optional `[h3]` extra: `pip install terraflow-agro[h3]`.
 - `ExportConfig` Pydantic model with `h3_resolution` field (validated 0–15) in `terraflow.config`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "terraflow-agro"
-version = "0.2.1"
+version = "0.2.2"
 description = "TerraFlow: a reproducible workflow for geospatial agricultural modeling."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/terraflow/__init__.py
+++ b/terraflow/__init__.py
@@ -9,6 +9,7 @@ This package provides utilities to:
 """
 
 from .config import PipelineConfig, load_config
+from .export import to_h3
 from .pipeline import run_pipeline
 from .stats import (
     ClimateSummary,
@@ -19,7 +20,6 @@ from .stats import (
     summarize_raster,
     summarize_raster_file,
 )
-from .export import to_h3
 from .validation import run_validation
 
 __all__ = [
@@ -38,4 +38,4 @@ __all__ = [
 ]
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
Version bump to 0.2.2. Updates `pyproject.toml`, `terraflow/__init__.py`, and `CHANGELOG.md`.