### PR TITLE
chore: strip excessive comments, refactor run_pipeline, update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+- Removed decorative section-banner comments and self-evident inline comments throughout `pipeline.py`, `ingest.py`, `geo.py`, and `climate.py`; comments now appear only at genuinely complex logic.
+- Refactored `run_pipeline()` into four extracted helpers (`_project_cells_to_wgs84`, `_score_cells`, `_apply_monte_carlo`, `_build_report`) reducing the function from 425 lines to ~130 lines of orchestration and cutting cognitive complexity below SonarQube thresholds.
+- Moved `import math` inline call in `geo.py` to module-level import.
+
+### Fixed
+- Closed resolved issues: H3-01 (#60), H3-02 (#61), H3-03 (#62), H3-04 (#63), and #40 (all implemented in prior phases).
+
 ## [0.2.2] — 2026-04-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,15 +60,16 @@ All artifacts land under `<output_dir>/runs/<run_fingerprint>/` (where `output_d
 
 | Module | What it owns |
 |--------|-------------|
-| `cli.py` | Typer CLI — `run`, `sensitivity`, `validate` subcommands |
-| `config.py` | `PipelineConfig`, `ModelParams`, `ROI` Pydantic models |
+| `cli.py` | Typer CLI — `run`, `sensitivity`, `validate`, `export` subcommands |
+| `config.py` | `PipelineConfig`, `ModelParams`, `ROI`, `SensitivityConfig`, `ValidationConfig`, `ExportConfig` Pydantic models |
 | `ingest.py` | `RasterLayer`, `ClimateLayer`, `DataCatalog` |
 | `geo.py` | ROI clipping, CRS alignment |
 | `climate.py` | `ClimateInterpolator` (linear / kriging / IDW) |
-| `model.py` | `suitability_score`, `suitability_label` |
+| `model.py` | `suitability_score`, `suitability_label`, `suitability_score_array` |
 | `pipeline.py` | End-to-end orchestration, artifact writing |
 | `sensitivity.py` | Sobol' / Morris analysis |
 | `validation.py` | Spatial CV, kappa, Moran's I |
+| `export.py` | H3-indexed export adapter (`to_h3()`, `run_export()`) |
 | `core/run_identity.py` | Deterministic run fingerprinting |
 
 ## Tests
@@ -96,7 +97,7 @@ Version is declared in **two places** — both must be updated together:
 - `pyproject.toml` line `version = "X.Y.Z"`
 - `terraflow/__init__.py` `__version__ = "X.Y.Z"`
 
-Project follows [Semantic Versioning](https://semver.org). Current version: `0.2.1`.
+Project follows [Semantic Versioning](https://semver.org). Current version: `0.2.2`.
 
 ### Release steps
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -7,83 +7,84 @@ tags:
   - Reference
 ---
 
-# TerraFlow Overview
+# TerraFlow Architecture Overview
 
-TerraFlow is a reproducible geospatial modeling framework that turns local geospatial inputs into
-traceable, analysis-ready artifacts. The core pipeline focuses on deterministic processing of
-region-of-interest (ROI) geographies and raster stacks so that every run can be recreated and
-audited with confidence.
+TerraFlow is a config-driven geospatial pipeline for agricultural suitability modeling. Given a raster (land-cover GeoTIFF) and a climate CSV, it produces scored, location-stamped cell features with full provenance tracking.
 
-## Inputs (v0.2.0)
-
-- YAML configuration file.
-- ROI boundary defined in the YAML (bbox).
-- Local GeoTIFF raster input (for example, `data/usda_cdl.tif`).
-- Local climate CSV input with lat/lon coordinates (for example, `data/demo_climate.csv`) — **enhanced in v0.2.0 with spatial interpolation**.
-
-## Outputs (v0.2.0 stable contract)
-
-All outputs are written under a deterministic run directory:
+## Data Flow
 
 ```
-outputs/<run_name>/
+YAML config → PipelineConfig (Pydantic v2)
+                 ↓
+DataCatalog  ← ingest.py (metadata only; no pixel reads)
+                 ↓
+run_fingerprint ← core/run_identity.py (SHA256 of config + inputs)
+                 ↓
+geo.py  → clip raster to ROI bbox; reproject to EPSG:4326
+                 ↓
+climate.py → ClimateInterpolator (linear | kriging | IDW)
+                 ↓
+model.py → suitability_score() + suitability_label()
+                 ↓
+pipeline.py → write artifacts to output_dir/runs/<fingerprint>/
 ```
 
-- `results.csv`: extracted features and scores per sampled cell (now with **per-cell climate values in v0.2.0**).
-- `manifest.json`: canonicalized inputs, file fingerprints, and provenance metadata.
-- `report.json`: QA summaries, timing, and coverage statistics.
+## Module Map
 
-For example, a demo configuration that sets `output_dir: "outputs/demo_run"` will emit
-`outputs/demo_run/results.csv` alongside the manifest and report.
+| Module | Responsibility |
+|--------|---------------|
+| `cli.py` | Typer CLI — `run`, `sensitivity`, `validate`, `export` subcommands |
+| `config.py` | Pydantic v2 models — `PipelineConfig`, `ModelParams`, `ROI`, `SensitivityConfig`, `ValidationConfig`, `ExportConfig` |
+| `ingest.py` | `RasterLayer`, `ClimateLayer`, `DataCatalog` — metadata only, no pixel I/O |
+| `geo.py` | ROI clipping, CRS reprojection; invariant: all output in EPSG:4326 |
+| `climate.py` | `ClimateInterpolator` — linear / kriging / IDW; LOOCV variogram selection |
+| `model.py` | `suitability_score()`, `suitability_label()`, `suitability_score_array()` |
+| `pipeline.py` | Orchestration — fingerprint → load → clip → interpolate → score → write |
+| `sensitivity.py` | Sobol' / Morris via SALib — triggered by `terraflow sensitivity` |
+| `validation.py` | Spatial block CV, Cohen's kappa, Moran's I — triggered by `terraflow validate` |
+| `export.py` | H3 hexagonal re-index — triggered by `terraflow export --format h3` |
+| `core/run_identity.py` | Deterministic SHA256 fingerprint of canonicalized config + input files |
 
-## Canonical pipeline
+## Output Artifacts
 
-```mermaid
-flowchart TD
-  A[YAML config] --> C[terraflow.core]
-  B[ROI bbox] --> C
-  D[Local GeoTIFF raster] --> E[Dataset resolution layer &#40future&#41]
-  F[Local climate CSV] --> E
-  E --> C
-  C --> G[Compute run_fingerprint]
-  G --> H[Raster/vector processing\nCRS align • mask/clip • zonal stats]
-  H --> I[outputs/run_name/results.csv]
-  H --> J[outputs/run_name/manifest.json]
-  H --> K[outputs/run_name/report.json]
-```
+All artifacts land under `<output_dir>/runs/<run_fingerprint>/`:
 
-## How a run works
+| File | Schema | Contents |
+|------|--------|----------|
+| `features.parquet` | v1 | `run_id, cell_id, lat, lon, v_index, mean_temp, total_rain, score, label` (+ kriging std + CI columns when configured) |
+| `manifest.json` | v1 | Config snapshot, input fingerprints, code version, git SHA |
+| `report.json` | v1 | Coverage fractions, raster/climate stats, score stats, timings; `kriging_loocv`, `kriging_diagnostics`, `uncertainty`, and `validation` blocks appended when the relevant features are enabled |
+| `results.csv` | — | Same data as `features.parquet` in CSV format (backward compatibility) |
+| `sensitivity_report.json` | — | Sobol' and/or Morris indices per `ModelParams` weight (written by `terraflow sensitivity`) |
+| `h3_resolution_N.parquet` | — | H3-indexed features at resolution N (written by `terraflow export --format h3`) |
 
-1. **Load configuration** and normalize relevant settings.
-2. **Load and normalize the ROI** geometry for consistent spatial operations.
-3. **Resolve local datasets** via the dataset resolution layer (future) for raster and climate sources.
-4. **Compute the run_fingerprint** deterministically.
-5. **Execute raster/vector processing** for clipping, masking, and zonal statistics.
-6. **Write outputs** with timings and QA summaries for inspection.
+## Key Invariants
 
-## Reproducibility
+- **CRS:** always EPSG:4326 in output. `geo.py` reprojects any input that differs.
+- **Determinism:** identical inputs always produce the same `run_fingerprint`. Cell sampling is seeded from the fingerprint SHA256 so that the same config yields the same cell set across independent runs.
+- **Cache:** if all three required artifacts exist in the run directory, the pipeline returns immediately without re-running.
+- **Coverage:** runs fail if no valid raster cells are found in the ROI; coverage fractions are always reported in `report.json`.
+- **Atomicity:** all artifacts are written with a write-to-temp + rename pattern to prevent partial writes.
 
-The `run_fingerprint` is a base64-url-safe hash derived from canonicalized configuration, a
-stable ROI geometry hash, and fingerprints of the input files. This makes each run immutable
-and comparable. The `manifest.json` captures the canonical inputs and file fingerprints, while
-`report.json` records timing and QA summaries that explain what the run produced.
+## Reproducibility Model
 
-## Geospatial correctness
+The `run_fingerprint` is a SHA256 over:
+1. Canonicalized (key-sorted) YAML config
+2. A stable ROI geometry hash (bbox dict or GeoJSON file hash)
+3. SHA256 fingerprints of all input files (raster + CSV)
 
-TerraFlow treats geospatial correctness as a first-class concern:
+This makes each run directory immutable. Re-running with identical inputs is a no-op; changing any input or config parameter produces a new directory.
 
-- **CRS strategy:** ROI geometries are normalized and aligned to raster CRS expectations before
-  extraction begins.
-- **Clipping and masking:** raster data is clipped and masked to the ROI boundary to avoid
-  leaking pixels outside the target geography.
-- **NoData propagation:** nodata values are preserved through processing to prevent false
-  statistics.
-- **Coverage checks:** `report.json` summarizes nodata ratios and coverage statistics so runs can
-  be audited for spatial completeness.
+## Geospatial Correctness
 
-## Non-goals (v0.2.0)
+- ROI bounds in any CRS are reprojected to raster CRS before windowing (all four corners, then axis-aligned bounding box to handle non-linear projections).
+- Degenerate windows (NaN dimensions after reprojection) raise `ValueError` with diagnostic information.
+- NoData cells are masked and excluded from sampling; coverage fractions are reported.
+- Climate station coordinates are validated against `[-90, 90]` / `[-180, 180]` ranges at load time.
 
-- Remote dataset downloads or cloud-hosted sources.
-- A hosted platform, workflow engine, or orchestration service.
-- A GUI-first GIS tool.
-- A general-purpose raster processing library.
+## Non-goals
+
+- Remote dataset downloads or cloud-hosted rasters.
+- Real-time or streaming data ingestion.
+- GUI or web application layer.
+- General-purpose raster processing (use `rioxarray` or `rasterstats` instead).

--- a/terraflow/cli.py
+++ b/terraflow/cli.py
@@ -1,4 +1,5 @@
 """TerraFlow CLI — Typer-based subcommand interface."""
+
 from __future__ import annotations
 
 import sys
@@ -21,8 +22,16 @@ app = typer.Typer(
 def run_cmd(
     config: Annotated[
         Path,
-        typer.Option(..., "--config", "-c", exists=True, file_okay=True,
-                     dir_okay=False, readable=True, help="Path to YAML config file"),
+        typer.Option(
+            ...,
+            "--config",
+            "-c",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            help="Path to YAML config file",
+        ),
     ],
 ) -> None:
     """Run the geospatial modeling pipeline."""
@@ -48,12 +57,21 @@ def run_cmd(
 def sensitivity_cmd(
     config: Annotated[
         Path,
-        typer.Option(..., "--config", "-c", exists=True, file_okay=True,
-                     dir_okay=False, readable=True, help="Path to YAML config file"),
+        typer.Option(
+            ...,
+            "--config",
+            "-c",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            help="Path to YAML config file",
+        ),
     ],
 ) -> None:
     """Run Sobol' and/or Morris sensitivity analysis."""
     from .sensitivity import run_sensitivity
+
     try:
         report_path = run_sensitivity(config)
         logger.info(f"Sensitivity analysis complete. Report: {report_path}")
@@ -71,14 +89,23 @@ def sensitivity_cmd(
 def validate_cmd(
     config: Annotated[
         Path,
-        typer.Option(..., "--config", "-c", exists=True, file_okay=True,
-                     dir_okay=False, readable=True, help="Path to YAML config file"),
+        typer.Option(
+            ...,
+            "--config",
+            "-c",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            help="Path to YAML config file",
+        ),
     ],
 ) -> None:
     """Run model validation (spatial CV, Cohen's kappa, Moran's I)."""
     logger.info(f"TerraFlow validation starting with config: {config}")
     try:
         from .validation import run_validation
+
         run_validation(config)
     except ValueError as e:
         logger.error(f"Configuration error: {e}")
@@ -95,8 +122,16 @@ def validate_cmd(
 def export_cmd(
     config: Annotated[
         Path,
-        typer.Option(..., "--config", "-c", exists=True, file_okay=True,
-                     dir_okay=False, readable=True, help="Path to YAML config file"),
+        typer.Option(
+            ...,
+            "--config",
+            "-c",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            readable=True,
+            help="Path to YAML config file",
+        ),
     ],
     format: Annotated[
         str,
@@ -111,6 +146,7 @@ def export_cmd(
     logger.info(f"TerraFlow export starting with config: {config}, format: {format}")
     try:
         from .export import run_export
+
         output_path = run_export(config, resolution_override=resolution, format=format)
         logger.info(f"Export complete: {output_path}")
     except ValueError as e:

--- a/terraflow/climate.py
+++ b/terraflow/climate.py
@@ -204,10 +204,6 @@ class ClimateInterpolator:
             f"interpolation_method='{interpolation_method}', records={len(self.climate_df)}, variables={self.climate_columns}"
         )
 
-    # ------------------------------------------------------------------
-    # Initialisation helpers
-    # ------------------------------------------------------------------
-
     def _validate_columns(self) -> None:
         """Validate that climate data has required columns."""
         required_cols = {"lat", "lon"}
@@ -240,7 +236,9 @@ class ClimateInterpolator:
 
         nan_count = lats.isna().sum() + lons.isna().sum()
         if nan_count > 0:
-            logger.warning(f"Found {nan_count} NaN values in lat/lon coordinates. Removing rows with missing coordinates.")
+            logger.warning(
+                f"Found {nan_count} NaN values in lat/lon coordinates. Removing rows with missing coordinates."
+            )
             self.climate_df = self.climate_df.dropna(subset=["lat", "lon"])
 
         lat_min, lat_max = lats.min(), lats.max()
@@ -261,19 +259,19 @@ class ClimateInterpolator:
             try:
                 CoordinateRange(latitude=lat, longitude=lon)
             except ValueError as e:
-                raise ValueError(f"Row {idx}: Invalid coordinate ({lat}, {lon}): {e}") from e
+                raise ValueError(
+                    f"Row {idx}: Invalid coordinate ({lat}, {lon}): {e}"
+                ) from e
 
         duplicates = self.climate_df.duplicated(subset=["lat", "lon"], keep=False).sum()
         if duplicates > 0:
-            logger.warning(f"Found {duplicates} duplicate lat/lon coordinates in climate data. Interpolation may produce ambiguous results.")
+            logger.warning(
+                f"Found {duplicates} duplicate lat/lon coordinates in climate data. Interpolation may produce ambiguous results."
+            )
 
     def _compute_mean_climate(self) -> dict:
         """Cache mean values of each climate variable for fallback use."""
         return {col: float(self.climate_df[col].mean()) for col in self.climate_columns}
-
-    # ------------------------------------------------------------------
-    # Kriging initialisation: variogram selection + LOOCV
-    # ------------------------------------------------------------------
 
     def _init_kriging(self) -> None:
         """Select the best variogram model via LOOCV and compute CV metrics.
@@ -305,7 +303,6 @@ class ClimateInterpolator:
         lons = self.climate_df["lon"].values.astype(float)
         lats = self.climate_df["lat"].values.astype(float)
 
-        # --- Variogram model selection on the first climate variable ----------
         primary_var = self.climate_columns[0]
         vals_primary = self.climate_df[primary_var].values.astype(float)
 
@@ -315,12 +312,16 @@ class ClimateInterpolator:
         for model in _VARIOGRAM_MODELS:
             try:
                 rmse, _ = self._loocv(lons, lats, vals_primary, model)
-                logger.debug(f"Variogram '{model}': LOOCV RMSE={rmse:.4f} ({primary_var})")
+                logger.debug(
+                    f"Variogram '{model}': LOOCV RMSE={rmse:.4f} ({primary_var})"
+                )
                 if rmse < best_rmse:
                     best_rmse = rmse
                     best_model = model
             except (ValueError, RuntimeError, np.linalg.LinAlgError) as exc:
-                logger.debug(f"Variogram model '{model}' failed during selection: {exc}")
+                logger.debug(
+                    f"Variogram model '{model}' failed during selection: {exc}"
+                )
 
         if best_model is None:
             logger.warning(
@@ -330,13 +331,16 @@ class ClimateInterpolator:
             return
 
         self._krig_variogram_model = best_model
-        logger.info(f"Kriging variogram selected: '{best_model}' (LOOCV RMSE={best_rmse:.4f} for '{primary_var}')")
+        logger.info(
+            f"Kriging variogram selected: '{best_model}' (LOOCV RMSE={best_rmse:.4f} for '{primary_var}')"
+        )
 
-        # Extract variogram parameters from a full-data fit with the selected model.
         from pykrige.ok import OrdinaryKriging
 
         _ok_full = OrdinaryKriging(
-            lons, lats, vals_primary,
+            lons,
+            lats,
+            vals_primary,
             variogram_model=best_model,
             verbose=False,
             enable_plotting=False,
@@ -351,7 +355,6 @@ class ClimateInterpolator:
             "range_units": "degrees_geographic",
         }
 
-        # --- Full LOOCV for all variables with the selected model -------------
         cv_per_var: Dict = {}
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
@@ -393,10 +396,6 @@ class ClimateInterpolator:
         errs = np.array(errors)
         return float(np.sqrt(np.mean(errs**2))), float(np.mean(np.abs(errs)))
 
-    # ------------------------------------------------------------------
-    # Public interface
-    # ------------------------------------------------------------------
-
     def interpolate(self, cell_lats: np.ndarray, cell_lons: np.ndarray) -> pd.DataFrame:
         """Interpolate or match climate data to cell locations.
 
@@ -434,10 +433,6 @@ class ClimateInterpolator:
         else:
             return self._match_by_index(cell_lats, cell_lons)
 
-    # ------------------------------------------------------------------
-    # Spatial interpolation dispatch
-    # ------------------------------------------------------------------
-
     def _interpolate_spatial(
         self, cell_lats: np.ndarray, cell_lons: np.ndarray
     ) -> pd.DataFrame:
@@ -473,7 +468,9 @@ class ClimateInterpolator:
                     fill_value=np.nan,
                 )
             except (ValueError, RuntimeError) as exc:
-                logger.info(f"Linear interpolation failed ({exc}), falling back to nearest-neighbor")
+                logger.info(
+                    f"Linear interpolation failed ({exc}), falling back to nearest-neighbor"
+                )
                 interp_values = griddata(
                     climate_points,
                     values,
@@ -486,7 +483,9 @@ class ClimateInterpolator:
                 nan_mask = np.isnan(interp_values)
                 if nan_mask.any():
                     interp_values[nan_mask] = self._climate_mean[col]
-                    logger.info(f"Filled {nan_mask.sum()} cells with mean {col} ({self._climate_mean[col]:.3f}) due to extrapolation")
+                    logger.info(
+                        f"Filled {nan_mask.sum()} cells with mean {col} ({self._climate_mean[col]:.3f}) due to extrapolation"
+                    )
             result[col] = interp_values
 
         return pd.DataFrame(result)
@@ -529,7 +528,9 @@ class ClimateInterpolator:
                 nan_mask = np.isnan(z_pred_arr)
                 if nan_mask.any():
                     z_pred_arr[nan_mask] = self._climate_mean[var]
-                    logger.info(f"Filled {nan_mask.sum()} NaN kriging predictions with mean {var}")
+                    logger.info(
+                        f"Filled {nan_mask.sum()} NaN kriging predictions with mean {var}"
+                    )
 
             result[var] = z_pred_arr
             result[f"{var}_krig_std"] = krig_std
@@ -561,7 +562,7 @@ class ClimateInterpolator:
                     # Cell coincides with a station — return exact value
                     interp_values[i] = vals[np.argmax(zero_mask)]
                 else:
-                    weights = 1.0 / (dists ** power)
+                    weights = 1.0 / (dists**power)
                     interp_values[i] = np.sum(weights * vals) / np.sum(weights)
 
             if self.fallback_to_mean:
@@ -572,10 +573,6 @@ class ClimateInterpolator:
             result[var] = interp_values
 
         return pd.DataFrame(result)
-
-    # ------------------------------------------------------------------
-    # Index-based matching
-    # ------------------------------------------------------------------
 
     def _match_by_index(
         self, cell_lats: np.ndarray, _cell_lons: np.ndarray
@@ -605,7 +602,9 @@ class ClimateInterpolator:
                         f"ensure climate CSV has at least {n_cells} rows."
                     )
             elif n_climate > n_cells:
-                logger.info(f"Climate records ({n_climate}) > cells ({n_cells}). Using first {n_cells} records.")
+                logger.info(
+                    f"Climate records ({n_climate}) > cells ({n_cells}). Using first {n_cells} records."
+                )
                 return self.climate_df[self.climate_columns].head(n_cells).copy()
             else:
                 return self.climate_df[self.climate_columns].copy()
@@ -615,5 +614,7 @@ class ClimateInterpolator:
                     f"cell_id_column '{self.cell_id_column}' not found in climate_df. "
                     f"Available columns: {list(self.climate_df.columns)}"
                 )
-            logger.info(f"Index-based matching using cell_id_column='{self.cell_id_column}'")
+            logger.info(
+                f"Index-based matching using cell_id_column='{self.cell_id_column}'"
+            )
             return self.climate_df[self.climate_columns].copy()

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -284,7 +284,9 @@ class PipelineConfig(BaseModel):
     model_params: ModelParams
     climate: ClimateConfig = ClimateConfig()  # Default: spatial strategy with fallback
     max_cells: int = 500  # maximum number of cells to sample from the ROI
-    sensitivity: Optional[SensitivityConfig] = None  # Optional sensitivity analysis config
+    sensitivity: Optional[SensitivityConfig] = (
+        None  # Optional sensitivity analysis config
+    )
     validation: Optional[ValidationConfig] = None  # Optional validation config
     export: Optional[ExportConfig] = None  # Optional H3 export config
 

--- a/terraflow/core/run_identity.py
+++ b/terraflow/core/run_identity.py
@@ -151,9 +151,7 @@ def compute_run_fingerprint(
         }
         for fp in input_fingerprints
     ]
-    inputs_payload.sort(
-        key=lambda item: (item["sha256"], item["size_bytes"])
-    )
+    inputs_payload.sort(key=lambda item: (item["sha256"], item["size_bytes"]))
 
     payload = {
         "config": config_hash,

--- a/terraflow/export.py
+++ b/terraflow/export.py
@@ -1,4 +1,5 @@
 """H3-indexed export adapter for TerraFlow pipeline output."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -41,18 +42,30 @@ def to_h3(features: pd.DataFrame, resolution: int = 8) -> pd.DataFrame:
         If resolution is outside 0-15 or required columns are missing.
     """
     if not _H3_AVAILABLE:
-        raise ImportError("h3 is required for H3 export. Install it with: pip install terraflow-agro[h3]")
+        raise ImportError(
+            "h3 is required for H3 export. Install it with: pip install terraflow-agro[h3]"
+        )
 
     if not (0 <= resolution <= 15):
         raise ValueError(f"H3 resolution must be 0-15, got {resolution}")
 
-    required_cols = {"lat", "lon", "score", "v_index", "mean_temp", "total_rain", "label"}
+    required_cols = {
+        "lat",
+        "lon",
+        "score",
+        "v_index",
+        "mean_temp",
+        "total_rain",
+        "label",
+    }
     missing = required_cols - set(features.columns)
     if missing:
         raise ValueError(f"Missing required columns: {missing}")
 
     features = features.copy()
-    features["h3_cell"] = features.apply(lambda row: h3.latlng_to_cell(row["lat"], row["lon"], resolution), axis=1)
+    features["h3_cell"] = features.apply(
+        lambda row: h3.latlng_to_cell(row["lat"], row["lon"], resolution), axis=1
+    )
 
     numeric_cols = ["score", "v_index", "mean_temp", "total_rain"]
     numeric_agg = features.groupby("h3_cell")[numeric_cols].mean()
@@ -98,7 +111,9 @@ def run_export(
         If no pipeline run directory containing ``features.parquet`` is found.
     """
     if format != "h3":
-        raise ValueError(f"Unsupported export format: '{format}'. Supported formats: h3")
+        raise ValueError(
+            f"Unsupported export format: '{format}'. Supported formats: h3"
+        )
 
     data = load_config_dict(config_path)
     cfg = build_config(data)
@@ -111,7 +126,11 @@ def run_export(
         )
 
     # Effective resolution: CLI override > config value (per D-01, D-12)
-    effective_resolution = resolution_override if resolution_override is not None else cfg.export.h3_resolution
+    effective_resolution = (
+        resolution_override
+        if resolution_override is not None
+        else cfg.export.h3_resolution
+    )
 
     if not (0 <= effective_resolution <= 15):
         raise ValueError(f"H3 resolution must be 0-15, got {effective_resolution}")

--- a/terraflow/geo.py
+++ b/terraflow/geo.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Dict, Tuple
 
 import numpy as np
@@ -44,11 +45,9 @@ def clip_raster_to_roi(
         If raster does not have band 1, ROI bounds are invalid, or the
         (reprojected) ROI does not intersect the raster extent.
     """
-    # Validate that band 1 exists
     if raster.count < 1:
         raise ValueError("Raster has no bands. Cannot read band 1.")
 
-    # Validate ROI bounds before any reprojection
     if roi["xmin"] >= roi["xmax"] or roi["ymin"] >= roi["ymax"]:
         raise ValueError(
             f"Invalid ROI bounds: xmin={roi['xmin']}, xmax={roi['xmax']}, "
@@ -58,7 +57,6 @@ def clip_raster_to_roi(
 
     xmin, ymin, xmax, ymax = roi["xmin"], roi["ymin"], roi["xmax"], roi["ymax"]
 
-    # Reproject ROI bounds to raster CRS when they differ.
     raster_crs = raster.crs
     src_crs = CRS.from_user_input(roi_crs)
     if src_crs != raster_crs:
@@ -74,11 +72,8 @@ def clip_raster_to_roi(
             f"xmin={xmin:.2f} ymin={ymin:.2f} xmax={xmax:.2f} ymax={ymax:.2f}"
         )
 
-    # Compute rasterio window from the (reprojected) bounds.
     try:
-        window: Window = from_bounds(
-            xmin, ymin, xmax, ymax, transform=raster.transform
-        )
+        window: Window = from_bounds(xmin, ymin, xmax, ymax, transform=raster.transform)
     except Exception as e:
         raise ValueError(
             f"Could not compute raster window for ROI bounds "
@@ -89,7 +84,6 @@ def clip_raster_to_roi(
     # Guard against degenerate windows (NaN dimensions) that arise when
     # reprojected bounds are numerically invalid (e.g. coordinates outside
     # the valid domain of the target CRS).
-    import math
     if math.isnan(window.width) or math.isnan(window.height):
         raise ValueError(
             f"ROI bounds ({xmin}, {ymin}, {xmax}, {ymax}) produced a "
@@ -98,7 +92,6 @@ def clip_raster_to_roi(
             f"coordinates are valid in that CRS."
         )
 
-    # Read the windowed data.
     data = raster.read(1, window=window, masked=True)
     transform = raster.window_transform(window)
 

--- a/terraflow/ingest.py
+++ b/terraflow/ingest.py
@@ -11,14 +11,6 @@ from rasterio.io import DatasetReader
 
 from .utils import logger
 
-# ---------------------------------------------------------------------------
-# DataCatalog — lightweight metadata contract for ingest layer
-# ---------------------------------------------------------------------------
-# Architecture boundary: this module resolves datasets from local files,
-# checks availability/coverage, and collects metadata.  It MUST NOT
-# orchestrate pipeline steps or write final features.
-# ---------------------------------------------------------------------------
-
 
 class RasterLayer(BaseModel):
     """Metadata for a single raster input layer."""
@@ -84,11 +76,6 @@ class DataCatalog(BaseModel):
         return None
 
 
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
 def _sha256_file(path: Path, chunk_size: int = 8_388_608) -> str:
     """Return SHA-256 hex digest of a file's contents."""
     hasher = hashlib.sha256()
@@ -99,11 +86,6 @@ def _sha256_file(path: Path, chunk_size: int = 8_388_608) -> str:
                 break
             hasher.update(chunk)
     return hasher.hexdigest()
-
-
-# ---------------------------------------------------------------------------
-# Public factory
-# ---------------------------------------------------------------------------
 
 
 def build_data_catalog(
@@ -149,7 +131,6 @@ def build_data_catalog(
     if not climate_csv_path.exists():
         raise FileNotFoundError(f"Climate CSV not found: {climate_csv_path}")
 
-    # --- Raster metadata (no pixel reads) -----------------------------------
     with rasterio.open(raster_path) as ds:
         crs_str = ds.crs.to_string() if ds.crs is not None else "unknown"
         bounds = (ds.bounds.left, ds.bounds.bottom, ds.bounds.right, ds.bounds.top)
@@ -170,7 +151,6 @@ def build_data_catalog(
         sha256=raster_sha,
     )
 
-    # --- Climate CSV metadata (header + coordinate scan only) ---------------
     climate_df_header = pd.read_csv(climate_csv_path, nrows=0)
     cols = list(climate_df_header.columns)
     if "lat" not in cols or "lon" not in cols:
@@ -179,7 +159,6 @@ def build_data_catalog(
         )
     climate_vars = [c for c in cols if c not in ("lat", "lon")]
 
-    # Read only lat/lon for range computation (lightweight).
     coord_df = pd.read_csv(climate_csv_path, usecols=["lat", "lon"]).dropna()
     n_rows = len(coord_df)
     lat_range = (float(coord_df["lat"].min()), float(coord_df["lat"].max()))
@@ -205,11 +184,6 @@ def build_data_catalog(
         raster_layers=[raster_layer],
         climate_layers=[climate_layer],
     )
-
-
-# ---------------------------------------------------------------------------
-# Low-level loaders (kept for backward compatibility)
-# ---------------------------------------------------------------------------
 
 
 def load_raster(path: str | Path) -> DatasetReader:
@@ -294,7 +268,6 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
     except pd.errors.ParserError as e:
         raise pd.errors.ParserError(f"Failed to parse CSV file {path}: {e}") from e
 
-    # Validate required columns
     required_cols = {"lat", "lon"}
     if not required_cols.issubset(df.columns):
         raise ValueError(
@@ -302,7 +275,6 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
             f"Found columns: {list(df.columns)}"
         )
 
-    # Identify climate variable columns (not lat/lon)
     climate_cols = set(df.columns) - {"lat", "lon"}
     if len(climate_cols) == 0:
         raise ValueError(
@@ -312,7 +284,6 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
 
     logger.info(f"Climate variables: {sorted(climate_cols)}")
 
-    # Remove rows with missing lat/lon
     initial_len = len(df)
     df = df.dropna(subset=["lat", "lon"])
     if len(df) < initial_len:
@@ -320,7 +291,6 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
             f"Dropped {initial_len - len(df)} rows with missing lat/lon coordinates"
         )
 
-    # Validate latitude range
     if (df["lat"] < -90).any() or (df["lat"] > 90).any():
         bad_lats = df[(df["lat"] < -90) | (df["lat"] > 90)]
         raise ValueError(
@@ -329,7 +299,6 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
             f"Bad values: {bad_lats['lat'].unique()}"
         )
 
-    # Validate longitude range
     if (df["lon"] < -180).any() or (df["lon"] > 180).any():
         bad_lons = df[(df["lon"] < -180) | (df["lon"] > 180)]
         raise ValueError(
@@ -338,14 +307,12 @@ def load_climate_csv(path: str | Path) -> pd.DataFrame:
             f"Bad values: {bad_lons['lon'].unique()}"
         )
 
-    # Warn about NaN values in climate variables
     nan_counts = df[list(climate_cols)].isna().sum()
     if nan_counts.any():
         logger.warning(
             f"Found NaN values in climate variables: {nan_counts[nan_counts > 0].to_dict()}"
         )
 
-    # Warn about duplicate coordinates
     duplicates = df.duplicated(subset=["lat", "lon"], keep=False).sum()
     if duplicates > 0:
         logger.warning(f"Found {duplicates} records with duplicate lat/lon coordinates")

--- a/terraflow/pipeline.py
+++ b/terraflow/pipeline.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+import rasterio
 from pyproj import Transformer
 from pyproj.exceptions import CRSError as _PyProjCRSError
 from rasterio.crs import CRS
@@ -49,37 +50,22 @@ from .ingest import build_data_catalog, load_climate_csv, load_raster
 from .model import suitability_label, suitability_score, suitability_score_array
 from .utils import ensure_dir, logger
 
-# ---------------------------------------------------------------------------
-# Schema contract
-# ---------------------------------------------------------------------------
-
 #: Tidy/wide schema for features.parquet (v1).
-#:
-#: Rationale for wide format: each *row* is one sampled cell (the natural
-#: observation unit); each *column* is one feature.  This matches the output
-#: contract of rasterstats, GeoPandas zonal_stats, and standard GIS tool
-#: pipelines.  Adding new climate variables in future releases appends columns
-#: and is backward-compatible via nullable columns.  The ``run_id`` column
-#: allows joining across runs and multi-run longitudinal datasets.
 FEATURES_SCHEMA_VERSION = "1"
 FEATURES_COLUMNS_ORDERED = [
-    "run_id",       # str   — run_fingerprint (links to manifest.json)
-    "cell_id",      # int64 — 0-based sampled-cell index (stable within a run)
-    "lat",          # float64 — WGS84 latitude (degrees N), always geographic
-    "lon",          # float64 — WGS84 longitude (degrees E), always geographic
-    "v_index",      # float64 — raster band-1 value (vegetation/crop index)
-    "mean_temp",    # float64 — interpolated mean temperature (°C)
-    "total_rain",   # float64 — interpolated total rainfall (mm)
-    "score",        # float64 — composite suitability score in [0.0, 1.0]
-    "label",        # str    — categorical: "low" / "medium" / "high"
+    "run_id",  # str   — run_fingerprint (links to manifest.json)
+    "cell_id",  # int64 — 0-based sampled-cell index (stable within a run)
+    "lat",  # float64 — WGS84 latitude (degrees N), always geographic
+    "lon",  # float64 — WGS84 longitude (degrees E), always geographic
+    "v_index",  # float64 — raster band-1 value (vegetation/crop index)
+    "mean_temp",  # float64 — interpolated mean temperature (°C)
+    "total_rain",  # float64 — interpolated total rainfall (mm)
+    "score",  # float64 — composite suitability score in [0.0, 1.0]
+    "label",  # str    — categorical: "low" / "medium" / "high"
 ]
 
 MANIFEST_SCHEMA_VERSION = "1"
 REPORT_SCHEMA_VERSION = "1"
-
-# ---------------------------------------------------------------------------
-# Internal helpers — path resolution
-# ---------------------------------------------------------------------------
 
 
 def _expand_input_paths(path_value: str, config_dir: Path) -> List[Path]:
@@ -193,11 +179,6 @@ def _resolve_roi_hash(config_dict: dict, config_dir: Path) -> str:
     raise ValueError("ROI configuration missing or unsupported")
 
 
-# ---------------------------------------------------------------------------
-# Public helper — locate a run directory by fingerprint
-# ---------------------------------------------------------------------------
-
-
 def resolve_run_dir(config_path: Path | str) -> Path:
     """Return the run directory for a given config without running the pipeline.
 
@@ -236,11 +217,6 @@ def resolve_run_dir(config_path: Path | str) -> Path:
     return output_dir / "runs" / run_fingerprint
 
 
-# ---------------------------------------------------------------------------
-# Deprecated helper (kept for backward-compat; used by existing tests)
-# ---------------------------------------------------------------------------
-
-
 def _aggregate_climate(climate_df: pd.DataFrame) -> Dict[str, float]:
     """
     Aggregate climate data into simple summary statistics (deprecated).
@@ -266,11 +242,6 @@ def _aggregate_climate(climate_df: pd.DataFrame) -> Dict[str, float]:
     return result
 
 
-# ---------------------------------------------------------------------------
-# Atomic I/O helpers
-# ---------------------------------------------------------------------------
-
-
 def _atomic_write_text(path: Path, content: str) -> None:
     """Write *content* to *path* atomically (write-to-tmp, rename)."""
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
@@ -292,15 +263,14 @@ def _atomic_write_parquet(path: Path, df: pd.DataFrame, schema_meta: dict) -> No
     import pyarrow.parquet as pq
 
     table = pa.Table.from_pandas(df, preserve_index=False)
-    # Merge custom schema version metadata into existing Parquet metadata.
     existing_meta = table.schema.metadata or {}
     merged_meta = {
         **existing_meta,
         b"terraflow_schema_version": FEATURES_SCHEMA_VERSION.encode(),
         **{
-            k.encode() if isinstance(k, str) else k: v.encode()
-            if isinstance(v, str)
-            else v
+            k.encode() if isinstance(k, str) else k: (
+                v.encode() if isinstance(v, str) else v
+            )
             for k, v in schema_meta.items()
         },
     }
@@ -319,11 +289,6 @@ def _atomic_write_parquet(path: Path, df: pd.DataFrame, schema_meta: dict) -> No
         raise
 
 
-# ---------------------------------------------------------------------------
-# Git SHA helper (optional; gracefully omitted when unavailable)
-# ---------------------------------------------------------------------------
-
-
 def _get_git_sha() -> Optional[str]:
     """Return the current HEAD SHA, or ``None`` if not in a git repo."""
     try:
@@ -340,9 +305,201 @@ def _get_git_sha() -> Optional[str]:
     return None
 
 
-# ---------------------------------------------------------------------------
-# Main pipeline entry point
-# ---------------------------------------------------------------------------
+def _project_cells_to_wgs84(
+    sampled_indices: List[tuple[int, int]],
+    clipped_transform: rasterio.Affine,
+    raster_crs: CRS,
+) -> tuple[List[float], List[float]]:
+    """Return (cell_lats, cell_lons) in WGS84 for the sampled cell grid positions."""
+    native_xs: List[float] = []
+    native_ys: List[float] = []
+    for row, col in sampled_indices:
+        x, y = xy(clipped_transform, row, col, offset="center")
+        native_xs.append(float(x))
+        native_ys.append(float(y))
+
+    wgs84 = CRS.from_epsg(4326)
+    if raster_crs != wgs84:
+        coord_tf = Transformer.from_crs(raster_crs, wgs84, always_xy=True)
+        lons, lats = coord_tf.transform(native_xs, native_ys)
+        return list(lats), list(lons)
+    return native_ys, native_xs  # native_xs=lon, native_ys=lat
+
+
+def _score_cells(
+    clipped_data: np.ma.MaskedArray,
+    sampled_indices: List[tuple[int, int]],
+    cell_lats: List[float],
+    cell_lons: List[float],
+    cell_climate_df: pd.DataFrame,
+    cfg: PipelineConfig,
+    run_fingerprint: str,
+) -> tuple[pd.DataFrame, List[str]]:
+    """Score each sampled cell and return (features DataFrame, kriging std col names)."""
+    krig_std_cols = [c for c in cell_climate_df.columns if c.endswith("_krig_std")]
+    records: List[Dict[str, Any]] = []
+
+    for cell_id, (row, col) in enumerate(sampled_indices):
+        v_index = float(clipped_data[row, col])
+        mean_temp = float(cell_climate_df.iloc[cell_id]["mean_temp"])
+        total_rain = float(cell_climate_df.iloc[cell_id]["total_rain"])
+        score = suitability_score(
+            v_index=v_index,
+            mean_temp=mean_temp,
+            total_rain=total_rain,
+            params=cfg.model_params,
+        )
+        record: Dict[str, Any] = {
+            "run_id": run_fingerprint,
+            "cell_id": cell_id,
+            "lat": cell_lats[cell_id],
+            "lon": cell_lons[cell_id],
+            "v_index": v_index,
+            "mean_temp": mean_temp,
+            "total_rain": total_rain,
+            "score": score,
+            "label": suitability_label(score),
+        }
+        for ksc in krig_std_cols:
+            record[ksc] = float(cell_climate_df.iloc[cell_id][ksc])
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records)
+    return df, krig_std_cols
+
+
+def _apply_monte_carlo(
+    df: pd.DataFrame,
+    krig_std_cols: List[str],
+    cfg: PipelineConfig,
+    rng: np.random.Generator,
+) -> tuple[pd.DataFrame, List[str]]:
+    """Add Monte Carlo CI columns to *df* if configured; returns updated df and new col names.
+
+    Requires uncertainty_samples > 0 and kriging std columns present.
+    Perturbs mean_temp and total_rain using per-cell kriging std, then scores
+    each draw to derive 5th/95th percentile confidence intervals on the
+    suitability score.
+    """
+    n_mc = cfg.model_params.uncertainty_samples
+    if n_mc <= 0 or not krig_std_cols:
+        if n_mc > 0:
+            logger.warning(
+                f"uncertainty_samples={n_mc} but no kriging std columns available; "
+                "skipping Monte Carlo. Set interpolation_method='kriging' to enable."
+            )
+        return df, []
+
+    n_cells = len(df)
+    v_arr = df["v_index"].to_numpy()
+    temp_arr = df["mean_temp"].to_numpy()
+    rain_arr = df["total_rain"].to_numpy()
+    # Clip std to ≥ 0 (kriging variance is non-negative but may have
+    # tiny floating-point negatives at station locations).
+    temp_std = np.maximum(df["mean_temp_krig_std"].to_numpy(), 0.0)
+    rain_std = np.maximum(df["total_rain_krig_std"].to_numpy(), 0.0)
+
+    # Shape: (n_cells, n_mc) — rng continues deterministic stream.
+    temp_mc = rng.normal(temp_arr[:, None], temp_std[:, None], (n_cells, n_mc))
+    rain_mc = rng.normal(rain_arr[:, None], rain_std[:, None], (n_cells, n_mc))
+    # v_index has no per-cell uncertainty estimate; broadcast constant.
+    v_mc = np.broadcast_to(v_arr[:, None], (n_cells, n_mc))
+
+    scores_mc = suitability_score_array(v_mc, temp_mc, rain_mc, cfg.model_params)
+    df["score_ci_low"] = np.percentile(scores_mc, 5, axis=1)
+    df["score_ci_high"] = np.percentile(scores_mc, 95, axis=1)
+    logger.info(
+        f"Monte Carlo uncertainty propagation complete: {n_mc} samples per cell"
+    )
+    return df, ["score_ci_low", "score_ci_high"]
+
+
+def _build_report(
+    run_fingerprint: str,
+    clipped_data: np.ma.MaskedArray,
+    climate_df: pd.DataFrame,
+    df: pd.DataFrame,
+    n_cells_sampled: int,
+    n_total_cells: int,
+    n_valid_cells: int,
+    n_nodata_cells: int,
+    interpolator: "ClimateInterpolator",
+    mc_ci_cols: List[str],
+    n_mc: int,
+    timings: Dict[str, float],
+) -> Dict[str, Any]:
+    """Build the report.json payload."""
+    raster_vals = clipped_data.compressed().astype("float64")
+    climate_var_cols = [c for c in climate_df.columns if c not in ("lat", "lon")]
+    climate_var_stats: Dict[str, Any] = {
+        var: {
+            "mean": float(col.mean()) if len(col := climate_df[var].dropna()) else None,
+            "min": float(col.min()) if len(col) else None,
+            "max": float(col.max()) if len(col) else None,
+            "n_nodata": int(climate_df[var].isna().sum()),
+        }
+        for var in climate_var_cols
+    }
+    scores_arr = df["score"].to_numpy()
+
+    report: Dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "run_fingerprint": run_fingerprint,
+        "coverage": {
+            "n_raster_cells_total": n_total_cells,
+            "n_roi_valid_cells": n_valid_cells,
+            "n_roi_nodata_cells": n_nodata_cells,
+            "roi_coverage_fraction": (
+                round(n_valid_cells / n_total_cells, 6) if n_total_cells else 0.0
+            ),
+            "roi_nodata_fraction": (
+                round(n_nodata_cells / n_total_cells, 6) if n_total_cells else 0.0
+            ),
+        },
+        "raster_stats": {
+            "count": int(raster_vals.size),
+            "mean": float(raster_vals.mean()) if raster_vals.size else None,
+            "std": float(raster_vals.std(ddof=1)) if raster_vals.size > 1 else 0.0,
+            "min": float(raster_vals.min()) if raster_vals.size else None,
+            "max": float(raster_vals.max()) if raster_vals.size else None,
+        },
+        "climate_stats": {"n_rows": len(climate_df), "variables": climate_var_stats},
+        "n_cells_sampled": n_cells_sampled,
+        "score_stats": {
+            "mean": float(scores_arr.mean()) if len(scores_arr) else None,
+            "std": float(scores_arr.std(ddof=1)) if len(scores_arr) > 1 else 0.0,
+            "min": float(scores_arr.min()) if len(scores_arr) else None,
+            "max": float(scores_arr.max()) if len(scores_arr) else None,
+        },
+        "timings_sec": timings,
+    }
+
+    if interpolator.cv_metrics:
+        report["kriging_loocv"] = {
+            var: round(stats["rmse"], 6)
+            for var, stats in interpolator.cv_metrics.get("per_variable", {}).items()
+            if stats.get("rmse") is not None
+        }
+        report["interpolation_cv"] = interpolator.cv_metrics
+
+    if interpolator.variogram_params:
+        report["kriging_diagnostics"] = interpolator.variogram_params
+
+    if mc_ci_cols:
+        ci_low = df["score_ci_low"].to_numpy()
+        ci_high = df["score_ci_high"].to_numpy()
+        report["uncertainty"] = {
+            "method": "monte_carlo",
+            "n_samples": n_mc,
+            "perturbed_variables": ["mean_temp", "total_rain"],
+            "ci_low_pct": 5,
+            "ci_high_pct": 95,
+            "score_ci_low_mean": float(ci_low.mean()),
+            "score_ci_high_mean": float(ci_high.mean()),
+            "mean_ci_width": float((ci_high - ci_low).mean()),
+        }
+
+    return report
 
 
 def run_pipeline(config_path: str | Path) -> pd.DataFrame:
@@ -386,7 +543,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     config_dict = load_config_dict(config_path)
     config_dir = config_path.resolve().parent
 
-    # Resolve relative input/output paths against the config file's directory.
     for _key in ("raster_path", "climate_csv", "output_dir"):
         if _key in config_dict and config_dict[_key] is not None:
             _p = Path(str(config_dict[_key]))
@@ -395,7 +551,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
 
     cfg: PipelineConfig = build_config(config_dict)
     logger.info(f"Loaded config from {config_path}")
-
     config_bytes_hash = hashlib.sha256(canonicalize_config(config_dict)).hexdigest()
     roi_hash = _resolve_roi_hash(config_dict, config_dir)
     input_paths = _collect_input_paths(config_dict, config_dir)
@@ -414,7 +569,9 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         run_dir / "report.json",
     ]
     if all(p.exists() for p in _required_artifacts):
-        logger.info(f"Detected identical run {run_fingerprint} — all artifacts present, returning cached result.")
+        logger.info(
+            f"Detected identical run {run_fingerprint} — all artifacts present, returning cached result."
+        )
         df = pd.read_parquet(run_dir / "features.parquet")
         df.attrs["run_fingerprint"] = run_fingerprint
         df.attrs["run_dir"] = str(run_dir)
@@ -434,7 +591,11 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         raise
     _t_load = time.perf_counter() - _t_load_start
 
-    _crs_str = f"EPSG:{raster_crs.to_epsg()}" if raster_crs is not None and raster_crs.to_epsg() else (str(raster_crs) if raster_crs else "None")
+    _crs_str = (
+        f"EPSG:{raster_crs.to_epsg()}"
+        if raster_crs is not None and raster_crs.to_epsg()
+        else (str(raster_crs) if raster_crs else "None")
+    )
     logger.info(f"Loaded raster: {cfg.raster_path} (CRS: {_crs_str})")
     logger.info(f"Loaded climate data: {cfg.climate_csv}")
 
@@ -462,11 +623,8 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     _t_clip = time.perf_counter() - _t_clip_start
     logger.info("Clipped raster to ROI")
 
-    rows: int
-    cols: int
     rows, cols = clipped_data.shape
     n_total_cells = rows * cols
-
     valid_indices: List[tuple[int, int]] = [
         (r, c)
         for r in range(rows)
@@ -502,114 +660,29 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     sampled_indices = [valid_indices[i] for i in _sample_idx]
     logger.info(f"Sampled {max_cells} cells from {n_valid_cells} valid cells in ROI")
 
-    # Pre-compute cell centre coordinates in native raster CRS.
-    _native_xs: List[float] = []
-    _native_ys: List[float] = []
-    for row, col in sampled_indices:
-        x, y = xy(clipped_transform, row, col, offset="center")
-        _native_xs.append(float(x))
-        _native_ys.append(float(y))
-
-    # Reproject to WGS84 (EPSG:4326).
-    _wgs84 = CRS.from_epsg(4326)
-    if raster_crs != _wgs84:
-        _coord_tf = Transformer.from_crs(raster_crs, _wgs84, always_xy=True)
-        _lons, _lats = _coord_tf.transform(_native_xs, _native_ys)
-        cell_lons: List[float] = list(_lons)
-        cell_lats: List[float] = list(_lats)
-    else:
-        cell_lons = _native_xs
-        cell_lats = _native_ys
+    cell_lats, cell_lons = _project_cells_to_wgs84(
+        sampled_indices, clipped_transform, raster_crs
+    )
 
     _t_interp_start = time.perf_counter()
     cell_climate_df = interpolator.interpolate(np.array(cell_lats), np.array(cell_lons))
     _t_interp = time.perf_counter() - _t_interp_start
-    logger.info(f"Interpolated climate for {len(sampled_indices)} cells using strategy='{cfg.climate.strategy}'")
+    logger.info(
+        f"Interpolated climate for {len(sampled_indices)} cells using strategy='{cfg.climate.strategy}'"
+    )
 
     _t_score_start = time.perf_counter()
-    records: List[Dict[str, Any]] = []
-
-    # Detect kriging std columns (present when interpolation_method="kriging").
-    _krig_std_cols = [c for c in cell_climate_df.columns if c.endswith("_krig_std")]
-
-    for cell_id, (row, col) in enumerate(sampled_indices):
-        v_index = float(clipped_data[row, col])
-        lat = cell_lats[cell_id]
-        lon = cell_lons[cell_id]
-        mean_temp = float(cell_climate_df.iloc[cell_id]["mean_temp"])
-        total_rain = float(cell_climate_df.iloc[cell_id]["total_rain"])
-
-        score = suitability_score(
-            v_index=v_index,
-            mean_temp=mean_temp,
-            total_rain=total_rain,
-            params=cfg.model_params,
-        )
-        label = suitability_label(score)
-
-        record: Dict[str, Any] = {
-            "run_id": run_fingerprint,
-            "cell_id": cell_id,
-            "lat": lat,
-            "lon": lon,
-            "v_index": v_index,
-            "mean_temp": mean_temp,
-            "total_rain": total_rain,
-            "score": score,
-            "label": label,
-        }
-        # Append per-cell kriging std columns when kriging was used.
-        for ksc in _krig_std_cols:
-            record[ksc] = float(cell_climate_df.iloc[cell_id][ksc])
-
-        records.append(record)
-
-    df = pd.DataFrame.from_records(records)
-
-    # --- Monte Carlo uncertainty propagation ---------------------------------
-    # Requires: uncertainty_samples > 0 AND kriging std columns present.
-    # Perturbs mean_temp and total_rain independently using their per-cell
-    # kriging standard deviations, then scores each draw to derive 5th/95th
-    # percentile confidence intervals on the suitability score.
-    _mc_ci_cols: List[str] = []
-    _n_mc = cfg.model_params.uncertainty_samples
-    if _n_mc > 0:
-        if _krig_std_cols:
-            _mc_ci_cols = ["score_ci_low", "score_ci_high"]
-            _n_cells = len(df)
-            _v_arr = df["v_index"].to_numpy()
-            _temp_arr = df["mean_temp"].to_numpy()
-            _rain_arr = df["total_rain"].to_numpy()
-            # Clip std to ≥ 0 (kriging variance is non-negative but may have
-            # tiny floating-point negatives at station locations).
-            _temp_std = np.maximum(df["mean_temp_krig_std"].to_numpy(), 0.0)
-            _rain_std = np.maximum(df["total_rain_krig_std"].to_numpy(), 0.0)
-
-            # Shape: (n_cells, n_mc) — rng continues deterministic stream.
-            _temp_mc = rng.normal(
-                _temp_arr[:, None], _temp_std[:, None], (_n_cells, _n_mc)
-            )
-            _rain_mc = rng.normal(
-                _rain_arr[:, None], _rain_std[:, None], (_n_cells, _n_mc)
-            )
-            # v_index has no per-cell uncertainty estimate; broadcast constant.
-            _v_mc = np.broadcast_to(_v_arr[:, None], (_n_cells, _n_mc))
-
-            _scores_mc = suitability_score_array(
-                _v_mc, _temp_mc, _rain_mc, cfg.model_params
-            )  # (n_cells, n_mc), values in [0, 1]
-
-            df["score_ci_low"] = np.percentile(_scores_mc, 5, axis=1)
-            df["score_ci_high"] = np.percentile(_scores_mc, 95, axis=1)
-            logger.info(f"Monte Carlo uncertainty propagation complete: {_n_mc} samples per cell")
-        else:
-            logger.warning(
-                f"uncertainty_samples={_n_mc} but no kriging std columns available; "
-                "skipping Monte Carlo. Set interpolation_method='kriging' to enable."
-            )
-
-    # Enforce stable base column order, then append kriging std and CI columns.
-    df = df[FEATURES_COLUMNS_ORDERED + _krig_std_cols + _mc_ci_cols]
+    df, krig_std_cols = _score_cells(
+        clipped_data,
+        sampled_indices,
+        cell_lats,
+        cell_lons,
+        cell_climate_df,
+        cfg,
+        run_fingerprint,
+    )
+    df, mc_ci_cols = _apply_monte_carlo(df, krig_std_cols, cfg, rng)
+    df = df[FEATURES_COLUMNS_ORDERED + krig_std_cols + mc_ci_cols]
     _t_score = time.perf_counter() - _t_score_start
 
     raster.close()
@@ -622,7 +695,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         df,
         schema_meta={"run_fingerprint": run_fingerprint},
     )
-
     _atomic_write_text(run_dir / "results.csv", df.to_csv(index=False))
 
     git_sha = _get_git_sha()
@@ -653,114 +725,46 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         ],
     }
     _atomic_write_text(
-        run_dir / "manifest.json",
-        json.dumps(manifest, indent=2, default=str),
+        run_dir / "manifest.json", json.dumps(manifest, indent=2, default=str)
     )
 
-    raster_data_for_report = clipped_data.compressed().astype("float64")
-    climate_var_cols = [c for c in climate_df.columns if c not in ("lat", "lon")]
-    climate_var_stats: Dict[str, Any] = {}
-    for var in climate_var_cols:
-        col = climate_df[var].dropna()
-        climate_var_stats[var] = {
-            "mean": float(col.mean()) if len(col) else None,
-            "min": float(col.min()) if len(col) else None,
-            "max": float(col.max()) if len(col) else None,
-            "n_nodata": int(climate_df[var].isna().sum()),
-        }
-
-    scores_arr = df["score"].to_numpy()
     _t_total = time.perf_counter() - _t_total_start
     _t_write = time.perf_counter() - _t_write_start
 
-    report: Dict[str, Any] = {
-        "schema_version": REPORT_SCHEMA_VERSION,
-        "run_fingerprint": run_fingerprint,
-        "coverage": {
-            "n_raster_cells_total": n_total_cells,
-            "n_roi_valid_cells": n_valid_cells,
-            "n_roi_nodata_cells": n_nodata_cells,
-            "roi_coverage_fraction": (
-                round(n_valid_cells / n_total_cells, 6) if n_total_cells else 0.0
-            ),
-            "roi_nodata_fraction": (
-                round(n_nodata_cells / n_total_cells, 6) if n_total_cells else 0.0
-            ),
-        },
-        "raster_stats": {
-            "count": int(raster_data_for_report.size),
-            "mean": float(raster_data_for_report.mean()) if raster_data_for_report.size else None,
-            "std": float(raster_data_for_report.std(ddof=1)) if raster_data_for_report.size > 1 else 0.0,
-            "min": float(raster_data_for_report.min()) if raster_data_for_report.size else None,
-            "max": float(raster_data_for_report.max()) if raster_data_for_report.size else None,
-        },
-        "climate_stats": {
-            "n_rows": len(climate_df),
-            "variables": climate_var_stats,
-        },
-        "n_cells_sampled": len(records),
-        "score_stats": {
-            "mean": float(scores_arr.mean()) if len(scores_arr) else None,
-            "std": float(scores_arr.std(ddof=1)) if len(scores_arr) > 1 else 0.0,
-            "min": float(scores_arr.min()) if len(scores_arr) else None,
-            "max": float(scores_arr.max()) if len(scores_arr) else None,
-        },
-        "timings_sec": {
-            "build_catalog": round(_t_catalog, 4),
-            "load_inputs": round(_t_load, 4),
-            "clip_roi": round(_t_clip, 4),
-            "interpolate_climate": round(_t_interp, 4),
-            "score_cells": round(_t_score, 4),
-            "write_outputs": round(_t_write, 4),
-            "total": round(_t_total, 4),
-        },
+    timings = {
+        "build_catalog": round(_t_catalog, 4),
+        "load_inputs": round(_t_load, 4),
+        "clip_roi": round(_t_clip, 4),
+        "interpolate_climate": round(_t_interp, 4),
+        "score_cells": round(_t_score, 4),
+        "write_outputs": round(_t_write, 4),
+        "total": round(_t_total, 4),
     }
-    # Include LOOCV cross-validation metrics when kriging was used.
-    if interpolator.cv_metrics:
-        # VALD-03: expose per-variable LOOCV RMSE under 'kriging_loocv'
-        report["kriging_loocv"] = {
-            var: round(stats["rmse"], 6)
-            for var, stats in interpolator.cv_metrics.get("per_variable", {}).items()
-            if stats.get("rmse") is not None
-        }
-        report["interpolation_cv"] = interpolator.cv_metrics  # retain for compat
-
-    # Include variogram diagnostics when kriging was used.
-    if interpolator.variogram_params:
-        report["kriging_diagnostics"] = interpolator.variogram_params
-
-    # Include Monte Carlo uncertainty summary when CI columns were produced.
-    if _mc_ci_cols:
-        _ci_low = df["score_ci_low"].to_numpy()
-        _ci_high = df["score_ci_high"].to_numpy()
-        report["uncertainty"] = {
-            "method": "monte_carlo",
-            "n_samples": _n_mc,
-            "perturbed_variables": ["mean_temp", "total_rain"],
-            "ci_low_pct": 5,
-            "ci_high_pct": 95,
-            "score_ci_low_mean": float(_ci_low.mean()),
-            "score_ci_high_mean": float(_ci_high.mean()),
-            "mean_ci_width": float((_ci_high - _ci_low).mean()),
-        }
-
+    report = _build_report(
+        run_fingerprint,
+        clipped_data,
+        climate_df,
+        df,
+        n_cells_sampled=len(df),
+        n_total_cells=n_total_cells,
+        n_valid_cells=n_valid_cells,
+        n_nodata_cells=n_nodata_cells,
+        interpolator=interpolator,
+        mc_ci_cols=mc_ci_cols,
+        n_mc=cfg.model_params.uncertainty_samples,
+        timings=timings,
+    )
     _atomic_write_text(
-        run_dir / "report.json",
-        json.dumps(report, indent=2, default=str),
+        run_dir / "report.json", json.dumps(report, indent=2, default=str)
     )
 
     logger.info(
-        f"Artifacts written to {run_dir} (fingerprint={run_fingerprint}, cells={len(records)}, total={_t_total:.2f}s)"
+        f"Artifacts written to {run_dir} (fingerprint={run_fingerprint}, cells={len(df)}, total={_t_total:.2f}s)"
     )
 
     df.attrs["run_fingerprint"] = run_fingerprint
     df.attrs["run_dir"] = str(run_dir)
     return df
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _get_package_version() -> str:

--- a/terraflow/sensitivity.py
+++ b/terraflow/sensitivity.py
@@ -1,4 +1,5 @@
 """Sensitivity analysis module -- Sobol' and Morris methods via SALib."""
+
 from __future__ import annotations
 
 import json
@@ -13,7 +14,7 @@ from SALib.analyze.sobol import analyze as sobol_analyze
 from SALib.sample.morris import sample as morris_sample
 from SALib.sample.sobol import sample as sobol_sample
 
-from .config import PipelineConfig, SensitivityConfig, load_config_dict, build_config
+from .config import PipelineConfig, SensitivityConfig, build_config, load_config_dict
 from .utils import ensure_dir, logger
 
 
@@ -85,7 +86,9 @@ def _run_sobol(
     dict:
         Sobol' result dict with S1, S1_conf, ST, ST_conf, ranking keys.
     """
-    logger.info(f"Running Sobol' analysis with N={n_samples} (total evaluations: {n_samples * 8})")
+    logger.info(
+        f"Running Sobol' analysis with N={n_samples} (total evaluations: {n_samples * 8})"
+    )
     param_values = sobol_sample(problem, n_samples, calc_second_order=True, seed=42)
     Y = _evaluate_model(param_values, cfg)
     Si = sobol_analyze(problem, Y, calc_second_order=True, seed=42)
@@ -122,7 +125,9 @@ def _run_morris(
     # Morris N = number of trajectories; derive from n_samples capped at 50
     n_trajectories = max(4, min(n_samples // 10, 50))
     total_evals = (problem["num_vars"] + 1) * n_trajectories
-    logger.info(f"Running Morris analysis with {n_trajectories} trajectories (total evaluations: {total_evals})")
+    logger.info(
+        f"Running Morris analysis with {n_trajectories} trajectories (total evaluations: {total_evals})"
+    )
 
     X = morris_sample(problem, N=n_trajectories, num_levels=4, seed=42)
     Y = _evaluate_model(X, cfg)

--- a/terraflow/validation.py
+++ b/terraflow/validation.py
@@ -1,4 +1,5 @@
 """Model validation module — spatial block CV, Cohen's kappa, Moran's I."""
+
 from __future__ import annotations
 
 import json
@@ -148,9 +149,7 @@ def _compute_kappa(
     float:
         Cohen's kappa in [-1, 1].
     """
-    cell_coords = np.column_stack(
-        [cells_df["lat"].values, cells_df["lon"].values]
-    )
+    cell_coords = np.column_stack([cells_df["lat"].values, cells_df["lon"].values])
     ref_coords = np.column_stack(
         [reference_df["lat"].values, reference_df["lon"].values]
     )
@@ -294,11 +293,15 @@ def run_validation(config_path: Path) -> Path:
 
     # Spatial block CV
     fold_accs = _spatial_block_cv(
-        lats, lons, labels,
+        lats,
+        lons,
+        labels,
         n_blocks_side=val_cfg.n_blocks_side,
         buffer_deg=val_cfg.buffer_deg,
     )
-    mean_fold_accuracy: Optional[float] = float(np.mean(fold_accs)) if fold_accs else None
+    mean_fold_accuracy: Optional[float] = (
+        float(np.mean(fold_accs)) if fold_accs else None
+    )
 
     # Moran's I on score residuals
     morans_i_val = _morans_i(lats, lons, scores - float(scores.mean()))
@@ -311,7 +314,9 @@ def run_validation(config_path: Path) -> Path:
         reference_df = pd.read_csv(ref_path)
         n_ref = len(reference_df)
         kappa = _compute_kappa(df, reference_df)
-        logger.info(f"Cohen's kappa computed from {n_ref} reference points: {kappa:.4f}")
+        logger.info(
+            f"Cohen's kappa computed from {n_ref} reference points: {kappa:.4f}"
+        )
 
     # Read existing report.json and append validation block
     report_path = run_dir / "report.json"
@@ -331,7 +336,9 @@ def run_validation(config_path: Path) -> Path:
         "cohen_kappa": kappa,
         "morans_i_residuals": morans_i_val,
         "kriging_loocv_rmse": report.get("kriging_loocv"),
-        "reference_dataset": str(val_cfg.reference_csv) if val_cfg.reference_csv else None,
+        "reference_dataset": (
+            str(val_cfg.reference_csv) if val_cfg.reference_csv else None
+        ),
         "n_reference_points": n_ref if kappa is not None else None,
         "note": (
             "model has no free parameters; fold accuracy reflects spatial "

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -28,13 +28,22 @@ import pytest
 import rasterio
 from rasterio.transform import from_origin
 
-from terraflow.core.run_identity import compute_run_fingerprint, fingerprint_file, hash_roi_geometry
+from terraflow.core.run_identity import (
+    compute_run_fingerprint,
+    fingerprint_file,
+    hash_roi_geometry,
+)
 from terraflow.ingest import ClimateLayer, DataCatalog, RasterLayer, build_data_catalog
-from terraflow.pipeline import FEATURES_COLUMNS_ORDERED, FEATURES_SCHEMA_VERSION, run_pipeline
+from terraflow.pipeline import (
+    FEATURES_COLUMNS_ORDERED,
+    FEATURES_SCHEMA_VERSION,
+    run_pipeline,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers / fixtures
 # ---------------------------------------------------------------------------
+
 
 def _make_config(
     tmp_path: Path,
@@ -111,7 +120,9 @@ class TestFeaturesParquetSchema:
         pq_df = pd.read_parquet(run_dir / "features.parquet")
         # pandas ≥ 2.x may return StringDtype or object for string cols
         assert pd.api.types.is_string_dtype(pq_df["run_id"]), "run_id must be string"
-        assert pd.api.types.is_integer_dtype(pq_df["cell_id"]), "cell_id must be integer"
+        assert pd.api.types.is_integer_dtype(
+            pq_df["cell_id"]
+        ), "cell_id must be integer"
         for col in ("lat", "lon", "v_index", "mean_temp", "total_rain", "score"):
             assert pd.api.types.is_float_dtype(pq_df[col]), f"{col} must be float"
         assert pd.api.types.is_string_dtype(pq_df["label"]), "label must be string"
@@ -125,7 +136,9 @@ class TestFeaturesParquetSchema:
         fp = df.attrs["run_fingerprint"]
 
         pq_df = pd.read_parquet(run_dir / "features.parquet")
-        assert (pq_df["run_id"] == fp).all(), "All run_id values must match run_fingerprint"
+        assert (
+            pq_df["run_id"] == fp
+        ).all(), "All run_id values must match run_fingerprint"
 
     def test_score_in_unit_interval(
         self, tmp_path, synthetic_raster, synthetic_climate_csv
@@ -198,9 +211,9 @@ class TestManifestJsonSchema:
             "input_fingerprints",
             "output_files",
         }
-        assert required.issubset(manifest.keys()), (
-            f"Missing manifest keys: {required - set(manifest.keys())}"
-        )
+        assert required.issubset(
+            manifest.keys()
+        ), f"Missing manifest keys: {required - set(manifest.keys())}"
 
     def test_run_fingerprint_is_consistent(
         self, tmp_path, synthetic_raster, synthetic_climate_csv
@@ -296,10 +309,15 @@ class TestReportJsonSchema:
 
         cov = report["coverage"]
         assert cov["n_raster_cells_total"] >= cov["n_roi_valid_cells"]
-        assert cov["n_roi_valid_cells"] + cov["n_roi_nodata_cells"] == cov["n_raster_cells_total"]
+        assert (
+            cov["n_roi_valid_cells"] + cov["n_roi_nodata_cells"]
+            == cov["n_raster_cells_total"]
+        )
         assert 0.0 <= cov["roi_coverage_fraction"] <= 1.0
         assert 0.0 <= cov["roi_nodata_fraction"] <= 1.0
-        assert abs(cov["roi_coverage_fraction"] + cov["roi_nodata_fraction"] - 1.0) < 1e-6
+        assert (
+            abs(cov["roi_coverage_fraction"] + cov["roi_nodata_fraction"] - 1.0) < 1e-6
+        )
 
     def test_timings_all_positive(
         self, tmp_path, synthetic_raster, synthetic_climate_csv
@@ -354,9 +372,9 @@ class TestDeterminism:
         fps2 = [fingerprint_file(str(f))]
         fp2 = compute_run_fingerprint(cfg, roi_hash, fps2)
 
-        assert fp1 == fp2, (
-            "run_fingerprint must be content-based; mtime change must not alter it"
-        )
+        assert (
+            fp1 == fp2
+        ), "run_fingerprint must be content-based; mtime change must not alter it"
 
     def test_same_pipeline_run_twice_produces_identical_fingerprint(
         self, tmp_path, synthetic_raster, synthetic_climate_csv
@@ -409,9 +427,15 @@ class TestCrsMismatch:
         transform = from_origin(west=-100.0, north=40.0, xsize=0.01, ysize=0.01)
 
         with rasterio.open(
-            raster_path, "w", driver="GTiff",
-            height=5, width=5, count=1, dtype="float32",
-            crs="EPSG:4326", transform=transform,
+            raster_path,
+            "w",
+            driver="GTiff",
+            height=5,
+            width=5,
+            count=1,
+            dtype="float32",
+            crs="EPSG:4326",
+            transform=transform,
         ) as dst:
             dst.write(arr, 1)
 
@@ -475,14 +499,20 @@ class TestNodataCoverage:
         """Raster with half nodata cells must report coverage_fraction < 1.0."""
         raster_path = tmp_path / "partial_nodata.tif"
         arr = np.full((4, 4), fill_value=-9999.0, dtype="float32")
-        arr[0, :] = [1.0, 2.0, 3.0, 4.0]   # first row is valid
-        arr[1, :] = [5.0, 6.0, 7.0, 8.0]   # second row is valid
+        arr[0, :] = [1.0, 2.0, 3.0, 4.0]  # first row is valid
+        arr[1, :] = [5.0, 6.0, 7.0, 8.0]  # second row is valid
         transform = from_origin(west=-100.0, north=40.0, xsize=0.01, ysize=0.01)
 
         with rasterio.open(
-            raster_path, "w", driver="GTiff",
-            height=4, width=4, count=1, dtype="float32",
-            crs="EPSG:4326", transform=transform,
+            raster_path,
+            "w",
+            driver="GTiff",
+            height=4,
+            width=4,
+            count=1,
+            dtype="float32",
+            crs="EPSG:4326",
+            transform=transform,
             nodata=-9999.0,
         ) as dst:
             dst.write(arr, 1)
@@ -525,9 +555,9 @@ class TestNodataCoverage:
         with open(run_dir / "report.json", encoding="utf-8") as fh:
             report = json.load(fh)
 
-        assert report["coverage"]["roi_coverage_fraction"] < 1.0, (
-            "Expected coverage fraction < 1.0 with partial nodata raster"
-        )
+        assert (
+            report["coverage"]["roi_coverage_fraction"] < 1.0
+        ), "Expected coverage fraction < 1.0 with partial nodata raster"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -270,7 +270,8 @@ def test_cli_old_flat_command_fails(tmp_path: Path):
 
 def test_sensitivity_cmd_success(tmp_path: Path):
     cfg = tmp_path / "config.yml"
-    cfg.write_text(f"""
+    cfg.write_text(
+        f"""
 raster_path: "{tmp_path}/fake.tif"
 climate_csv: "{tmp_path}/fake.csv"
 output_dir: "{tmp_path}/outputs"
@@ -302,7 +303,9 @@ sensitivity:
     high: 0.4
   n_samples: 64
   method: both
-""", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
     with patch.object(sys, "argv", ["terraflow", "sensitivity", "-c", str(cfg)]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -312,7 +315,8 @@ sensitivity:
 
 def test_sensitivity_nonpower_of_two(tmp_path: Path, capsys):
     cfg = tmp_path / "config.yml"
-    cfg.write_text(f"""
+    cfg.write_text(
+        f"""
 raster_path: "{tmp_path}/fake.tif"
 climate_csv: "{tmp_path}/fake.csv"
 output_dir: "{tmp_path}/outputs"
@@ -344,7 +348,9 @@ sensitivity:
     high: 0.4
   n_samples: 100
   method: sobol
-""", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
     with patch.object(sys, "argv", ["terraflow", "sensitivity", "-c", str(cfg)]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -355,7 +361,8 @@ sensitivity:
 
 def test_sensitivity_missing_section(tmp_path: Path, capsys):
     cfg = tmp_path / "config.yml"
-    cfg.write_text(f"""
+    cfg.write_text(
+        f"""
 raster_path: "{tmp_path}/fake.tif"
 climate_csv: "{tmp_path}/fake.csv"
 output_dir: "{tmp_path}/outputs"
@@ -375,7 +382,9 @@ model_params:
   w_v: 0.4
   w_t: 0.3
   w_r: 0.3
-""", encoding="utf-8")
+""",
+        encoding="utf-8",
+    )
     with patch.object(sys, "argv", ["terraflow", "sensitivity", "-c", str(cfg)]):
         with pytest.raises(SystemExit) as exc_info:
             main()
@@ -425,8 +434,13 @@ export:
     def test_cli_export_unsupported_format(self, tmp_path: Path, capsys):
         """export command exits 1 when format is unsupported."""
         cfg = self._minimal_export_config(tmp_path)
-        with patch.object(sys, "argv", ["terraflow", "export", "--format", "geojson", "-c", str(cfg)]):
-            with patch("terraflow.export.run_export", side_effect=ValueError("Unsupported export format: 'geojson'")):
+        with patch.object(
+            sys, "argv", ["terraflow", "export", "--format", "geojson", "-c", str(cfg)]
+        ):
+            with patch(
+                "terraflow.export.run_export",
+                side_effect=ValueError("Unsupported export format: 'geojson'"),
+            ):
                 with pytest.raises(SystemExit) as exc_info:
                     main()
                 assert exc_info.value.code == 1
@@ -436,8 +450,12 @@ export:
     def test_cli_export_h3_success(self, tmp_path: Path):
         """export command exits 0 on successful H3 export."""
         cfg = self._minimal_export_config(tmp_path)
-        fake_output = tmp_path / "outputs" / "runs" / "abc123" / "h3_resolution_8.parquet"
-        with patch.object(sys, "argv", ["terraflow", "export", "--format", "h3", "-c", str(cfg)]):
+        fake_output = (
+            tmp_path / "outputs" / "runs" / "abc123" / "h3_resolution_8.parquet"
+        )
+        with patch.object(
+            sys, "argv", ["terraflow", "export", "--format", "h3", "-c", str(cfg)]
+        ):
             with patch("terraflow.export.run_export", return_value=fake_output):
                 with pytest.raises(SystemExit) as exc_info:
                     main()
@@ -446,8 +464,13 @@ export:
     def test_cli_export_missing_h3(self, tmp_path: Path, capsys):
         """export command exits 1 when h3 package is not installed."""
         cfg = self._minimal_export_config(tmp_path)
-        with patch.object(sys, "argv", ["terraflow", "export", "--format", "h3", "-c", str(cfg)]):
-            with patch("terraflow.export.run_export", side_effect=ImportError("h3 is required...")):
+        with patch.object(
+            sys, "argv", ["terraflow", "export", "--format", "h3", "-c", str(cfg)]
+        ):
+            with patch(
+                "terraflow.export.run_export",
+                side_effect=ImportError("h3 is required..."),
+            ):
                 with pytest.raises(SystemExit) as exc_info:
                     main()
                 assert exc_info.value.code == 1
@@ -461,10 +484,13 @@ class TestValidateCLI:
     def test_validate_missing_config_section(self, tmp_path):
         """validate command exits 1 when config has no validation section."""
         cfg = tmp_path / "no_val.yml"
-        cfg.write_text("raster_path: fake.tif\nclimate_csv: fake.csv\noutput_dir: out\n")
+        cfg.write_text(
+            "raster_path: fake.tif\nclimate_csv: fake.csv\noutput_dir: out\n"
+        )
         from typer.testing import CliRunner
 
         from terraflow.cli import app
+
         runner = CliRunner()
         result = runner.invoke(app, ["validate", "-c", str(cfg)])
         assert result.exit_code != 0
@@ -474,7 +500,10 @@ class TestValidateCLI:
         from typer.testing import CliRunner
 
         from terraflow.cli import app
+
         runner = CliRunner()
         result = runner.invoke(app, ["validate", "--help"])
         assert result.exit_code == 0
-        assert "validation" in result.output.lower() or "config" in result.output.lower()
+        assert (
+            "validation" in result.output.lower() or "config" in result.output.lower()
+        )

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -643,7 +643,11 @@ class TestKrigingInterpolation:
             strategy="spatial",
             interpolation_method="kriging",
         )
-        assert interpolator._krig_variogram_model in ("spherical", "exponential", "gaussian")
+        assert interpolator._krig_variogram_model in (
+            "spherical",
+            "exponential",
+            "gaussian",
+        )
 
     def test_kriging_fallback_to_linear_too_few_stations(self):
         """Kriging must fall back to linear when stations < MIN_KRIGING_STATIONS."""
@@ -842,7 +846,15 @@ class TestPipelineKrigingIntegration:
         cfg_file.write_text(cfg_content, encoding="utf-8")
 
         df = run_pipeline(cfg_file)
-        report = json.loads((tmp_path / "outputs" / "runs" / df.attrs["run_fingerprint"] / "report.json").read_text())
+        report = json.loads(
+            (
+                tmp_path
+                / "outputs"
+                / "runs"
+                / df.attrs["run_fingerprint"]
+                / "report.json"
+            ).read_text()
+        )
 
         assert "interpolation_cv" in report
         cv = report["interpolation_cv"]
@@ -857,14 +869,16 @@ class TestPipelineKrigingIntegration:
 
 def test_kriging_fallback_sparse_stations():
     """With < MIN_KRIGING_STATIONS stations, kriging falls back to linear."""
-    from terraflow.climate import ClimateInterpolator, MIN_KRIGING_STATIONS
+    from terraflow.climate import MIN_KRIGING_STATIONS, ClimateInterpolator
 
-    sparse_df = pd.DataFrame({
-        "lat": [40.0, 40.01],
-        "lon": [-100.0, -99.99],
-        "mean_temp": [18.0, 20.0],
-        "total_rain": [100.0, 120.0],
-    })
+    sparse_df = pd.DataFrame(
+        {
+            "lat": [40.0, 40.01],
+            "lon": [-100.0, -99.99],
+            "mean_temp": [18.0, 20.0],
+            "total_rain": [100.0, 120.0],
+        }
+    )
     assert len(sparse_df) < MIN_KRIGING_STATIONS
 
     interpolator = ClimateInterpolator(

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -82,7 +82,9 @@ class TestSamplingDeterminism:
         synthetic_climate_csv: Path,
     ):
         """Same config + inputs → same cell lat/lon on every run (seeded sampling)."""
-        df1, df2 = self._run_twice_same_config(tmp_path, synthetic_raster, synthetic_climate_csv)
+        df1, df2 = self._run_twice_same_config(
+            tmp_path, synthetic_raster, synthetic_climate_csv
+        )
 
         assert list(df1["lat"]) == list(df2["lat"]), (
             "Seeded sampling contract violated: same inputs produced different cell lats.\n"
@@ -98,7 +100,9 @@ class TestSamplingDeterminism:
         synthetic_climate_csv: Path,
     ):
         """Same config + inputs → identical scores across recomputed runs."""
-        df1, df2 = self._run_twice_same_config(tmp_path, synthetic_raster, synthetic_climate_csv)
+        df1, df2 = self._run_twice_same_config(
+            tmp_path, synthetic_raster, synthetic_climate_csv
+        )
 
         pd.testing.assert_frame_equal(
             df1[["lat", "lon", "v_index", "score", "label"]].reset_index(drop=True),
@@ -116,7 +120,12 @@ class TestSamplingDeterminism:
         """run_pipeline must set df.attrs['run_fingerprint']."""
         from terraflow.pipeline import run_pipeline
 
-        cfg = _write_config(tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv, tmp_path / "out")
+        cfg = _write_config(
+            tmp_path / "cfg.yml",
+            synthetic_raster,
+            synthetic_climate_csv,
+            tmp_path / "out",
+        )
         df = run_pipeline(cfg)
         assert "run_fingerprint" in df.attrs
         assert isinstance(df.attrs["run_fingerprint"], str)
@@ -136,7 +145,9 @@ class TestSamplingDeterminism:
         from terraflow.pipeline import run_pipeline
 
         shared_out = tmp_path / "shared_out"
-        cfg = _write_config(tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv, shared_out)
+        cfg = _write_config(
+            tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv, shared_out
+        )
 
         df1 = run_pipeline(cfg)
         df2 = run_pipeline(cfg)  # cache hit

--- a/tests/test_e2e_smoke.py
+++ b/tests/test_e2e_smoke.py
@@ -35,9 +35,15 @@ def _make_synthetic_raster(path: Path) -> Path:
     arr = np.arange(25, dtype="float32").reshape(5, 5)
     transform = from_origin(west=-100.0, north=40.0, xsize=0.01, ysize=0.01)
     with rasterio.open(
-        path, "w", driver="GTiff",
-        height=5, width=5, count=1, dtype="float32",
-        crs="EPSG:4326", transform=transform,
+        path,
+        "w",
+        driver="GTiff",
+        height=5,
+        width=5,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
     ) as ds:
         ds.write(arr, 1)
     return path
@@ -45,12 +51,14 @@ def _make_synthetic_raster(path: Path) -> Path:
 
 def _make_synthetic_climate(path: Path) -> Path:
     """Write a 3-row climate CSV that falls within the synthetic raster extent."""
-    pd.DataFrame({
-        "lat":        [40.0,  40.01,  40.02],
-        "lon":        [-100.0, -99.99, -99.98],
-        "mean_temp":  [18.0,   19.0,   20.0],
-        "total_rain": [100.0, 120.0,  140.0],
-    }).to_csv(path, index=False)
+    pd.DataFrame(
+        {
+            "lat": [40.0, 40.01, 40.02],
+            "lon": [-100.0, -99.99, -99.98],
+            "mean_temp": [18.0, 19.0, 20.0],
+            "total_rain": [100.0, 120.0, 140.0],
+        }
+    ).to_csv(path, index=False)
     return path
 
 
@@ -91,9 +99,9 @@ max_cells: 10
 @pytest.mark.smoke
 def test_e2e_pipeline_produces_all_artifacts(tmp_path: Path) -> None:
     """Full pipeline run: synthetic inputs → all 4 artifacts present and valid."""
-    raster  = _make_synthetic_raster(tmp_path / "raster.tif")
+    raster = _make_synthetic_raster(tmp_path / "raster.tif")
     climate = _make_synthetic_climate(tmp_path / "climate.csv")
-    cfg     = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
+    cfg = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
 
     df = run_pipeline(cfg)
     run_dir = Path(df.attrs["run_dir"])
@@ -101,9 +109,9 @@ def test_e2e_pipeline_produces_all_artifacts(tmp_path: Path) -> None:
 
     # --- All four artifacts must exist on disk ---
     assert (run_dir / "features.parquet").exists(), "features.parquet missing"
-    assert (run_dir / "manifest.json").exists(),    "manifest.json missing"
-    assert (run_dir / "report.json").exists(),       "report.json missing"
-    assert (run_dir / "results.csv").exists(),       "results.csv missing"
+    assert (run_dir / "manifest.json").exists(), "manifest.json missing"
+    assert (run_dir / "report.json").exists(), "report.json missing"
+    assert (run_dir / "results.csv").exists(), "results.csv missing"
 
     # --- features.parquet: schema columns and basic value ranges ---
     pq = pd.read_parquet(run_dir / "features.parquet")
@@ -126,8 +134,9 @@ def test_e2e_pipeline_produces_all_artifacts(tmp_path: Path) -> None:
     # --- report.json: coverage invariant and timing sanity ---
     report = json.loads((run_dir / "report.json").read_text())
     cov = report["coverage"]
-    assert abs(cov["roi_coverage_fraction"] + cov["roi_nodata_fraction"] - 1.0) < 1e-5, \
-        "coverage fractions do not sum to 1"
+    assert (
+        abs(cov["roi_coverage_fraction"] + cov["roi_nodata_fraction"] - 1.0) < 1e-5
+    ), "coverage fractions do not sum to 1"
     assert report["n_cells_sampled"] == len(pq), "n_cells_sampled mismatch"
     assert report["timings_sec"]["total"] > 0, "total timing must be positive"
 
@@ -135,9 +144,9 @@ def test_e2e_pipeline_produces_all_artifacts(tmp_path: Path) -> None:
 @pytest.mark.smoke
 def test_e2e_noop_rerun_does_not_overwrite(tmp_path: Path) -> None:
     """Second identical run must return cached results without touching artifacts."""
-    raster  = _make_synthetic_raster(tmp_path / "raster.tif")
+    raster = _make_synthetic_raster(tmp_path / "raster.tif")
     climate = _make_synthetic_climate(tmp_path / "climate.csv")
-    cfg     = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
+    cfg = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
 
     df1 = run_pipeline(cfg)
     run_dir = Path(df1.attrs["run_dir"])
@@ -147,17 +156,20 @@ def test_e2e_noop_rerun_does_not_overwrite(tmp_path: Path) -> None:
     mtime_after = (run_dir / "features.parquet").stat().st_mtime
 
     assert df1.attrs["run_fingerprint"] == df2.attrs["run_fingerprint"]
-    assert mtime_before == mtime_after, "no-op rerun must not overwrite features.parquet"
+    assert (
+        mtime_before == mtime_after
+    ), "no-op rerun must not overwrite features.parquet"
 
 
 @pytest.mark.smoke
 def test_e2e_run_dir_named_after_fingerprint(tmp_path: Path) -> None:
     """Run directory name must equal the run_fingerprint string."""
-    raster  = _make_synthetic_raster(tmp_path / "raster.tif")
+    raster = _make_synthetic_raster(tmp_path / "raster.tif")
     climate = _make_synthetic_climate(tmp_path / "climate.csv")
-    cfg     = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
+    cfg = _write_config(tmp_path / "config.yml", raster, climate, tmp_path / "out")
 
     df = run_pipeline(cfg)
     run_dir = Path(df.attrs["run_dir"])
-    assert run_dir.name == df.attrs["run_fingerprint"], \
-        "run directory name must equal run_fingerprint"
+    assert (
+        run_dir.name == df.attrs["run_fingerprint"]
+    ), "run directory name must equal run_fingerprint"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,5 @@
 """Unit tests for terraflow.export (to_h3) and ExportConfig."""
+
 from __future__ import annotations
 
 import importlib
@@ -321,4 +322,6 @@ def test_resolution_changes_fingerprint():
     fp8 = compute_run_fingerprint(config_res8, roi_hash, [])
     fp4 = compute_run_fingerprint(config_res4, roi_hash, [])
 
-    assert fp8 != fp4, "Different h3_resolution values must produce distinct fingerprints"
+    assert (
+        fp8 != fp4
+    ), "Different h3_resolution values must produce distinct fingerprints"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -96,6 +96,7 @@ def test_run_pipeline_config_in_subdirectory(
 
     # Copy fixtures into tmp_path root so relative paths resolve correctly
     import shutil
+
     shutil.copy(synthetic_raster, tmp_path / synthetic_raster.name)
     shutil.copy(synthetic_climate_csv, tmp_path / synthetic_climate_csv.name)
 
@@ -142,13 +143,21 @@ def test_pipeline_lat_lon_wgs84_for_projected_raster(tmp_path: Path):
     raster_path = tmp_path / "utm_raster.tif"
     arr = np.arange(25, dtype="float32").reshape(5, 5)
     west_utm, north_utm, pixel_m = 500_000.0, 4_261_000.0, 1_000.0
-    transform = from_origin(west=west_utm, north=north_utm, xsize=pixel_m, ysize=pixel_m)
+    transform = from_origin(
+        west=west_utm, north=north_utm, xsize=pixel_m, ysize=pixel_m
+    )
     crs = CRS.from_epsg(32614)
 
     with rasterio.open(
-        raster_path, "w", driver="GTiff",
-        height=5, width=5, count=1, dtype="float32",
-        crs=crs, transform=transform,
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=5,
+        width=5,
+        count=1,
+        dtype="float32",
+        crs=crs,
+        transform=transform,
     ) as dst:
         dst.write(arr, 1)
 
@@ -193,8 +202,12 @@ max_cells: 5
 
     assert not df.empty
     # Core acceptance criterion: lat/lon must be geographic degrees
-    assert df["lat"].between(-90.0, 90.0).all(), f"lat out of range: {df['lat'].tolist()}"
-    assert df["lon"].between(-180.0, 180.0).all(), f"lon out of range: {df['lon'].tolist()}"
+    assert (
+        df["lat"].between(-90.0, 90.0).all()
+    ), f"lat out of range: {df['lat'].tolist()}"
+    assert (
+        df["lon"].between(-180.0, 180.0).all()
+    ), f"lon out of range: {df['lon'].tolist()}"
     # Scores still valid
     assert df["score"].between(0.0, 1.0).all()
 
@@ -277,9 +290,15 @@ def _write_no_crs_raster(path: Path) -> Path:
     arr = np.arange(25, dtype="float32").reshape(5, 5)
     transform = from_origin(west=-100.0, north=40.0, xsize=0.01, ysize=0.01)
     with rasterio.open(
-        path, "w", driver="GTiff",
-        height=5, width=5, count=1, dtype=arr.dtype,
-        crs=None, transform=transform,
+        path,
+        "w",
+        driver="GTiff",
+        height=5,
+        width=5,
+        count=1,
+        dtype=arr.dtype,
+        crs=None,
+        transform=transform,
     ) as dst:
         dst.write(arr, 1)
     return path
@@ -296,7 +315,9 @@ def test_crs_mismatch_error_none_crs(tmp_path, synthetic_climate_csv_dense):
 
     raster_path = _write_no_crs_raster(tmp_path / "data" / "no_crs.tif")
     cfg_path = _write_kriging_config(
-        tmp_path / "cfg.yml", raster_path, synthetic_climate_csv_dense,
+        tmp_path / "cfg.yml",
+        raster_path,
+        synthetic_climate_csv_dense,
         tmp_path / "out",
     )
     with pytest.raises(CRSMismatchError, match="has no CRS"):
@@ -313,7 +334,9 @@ def test_kriging_diagnostics_in_report(
 ):
     """report.json includes kriging_diagnostics when kriging is used."""
     cfg_path = _write_kriging_config(
-        tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv_dense,
+        tmp_path / "cfg.yml",
+        synthetic_raster,
+        synthetic_climate_csv_dense,
         tmp_path / "out",
     )
     df = run_pipeline(cfg_path)

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,11 +1,12 @@
 """Tests for terraflow.sensitivity — Sobol' and Morris sensitivity analysis."""
+
 from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 
 from terraflow.sensitivity import run_sensitivity
 
@@ -120,7 +121,9 @@ def test_sobol_index_bounds(tmp_path: Path) -> None:
     """S1 values in [-0.5, 1.5], ST >= 0, confidence intervals >= 0."""
     cfg_path = _write_config(tmp_path, method="sobol", n_samples=64)
     run_sensitivity(cfg_path)
-    report = json.loads((tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8"))
+    report = json.loads(
+        (tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8")
+    )
     sobol = report["sobol"]
 
     for name in ("w_v", "w_t", "w_r"):
@@ -140,7 +143,9 @@ def test_morris_produces_mu_star(tmp_path: Path) -> None:
     """run_sensitivity with method=morris produces mu_star, mu, sigma keys."""
     cfg_path = _write_config(tmp_path, method="morris")
     run_sensitivity(cfg_path)
-    report = json.loads((tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8"))
+    report = json.loads(
+        (tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8")
+    )
 
     assert "morris" in report, "morris key must be present for method=morris"
     morris = report["morris"]
@@ -160,11 +165,15 @@ def test_report_json_schema(tmp_path: Path) -> None:
     """sensitivity_report.json contains required top-level schema keys."""
     cfg_path = _write_config(tmp_path, method="both")
     run_sensitivity(cfg_path)
-    report = json.loads((tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8"))
+    report = json.loads(
+        (tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8")
+    )
 
     required_keys = {"schema_version", "method", "n_samples", "parameters", "bounds"}
     for key in required_keys:
-        assert key in report, f"Top-level key '{key}' missing from sensitivity_report.json"
+        assert (
+            key in report
+        ), f"Top-level key '{key}' missing from sensitivity_report.json"
 
     assert report["parameters"] == ["w_v", "w_t", "w_r"]
     assert report["method"] == "both"
@@ -173,7 +182,9 @@ def test_report_json_schema(tmp_path: Path) -> None:
     assert "morris" in report
 
 
-def test_report_written_to_output_dir(sensitivity_config_path: Path, tmp_path: Path) -> None:
+def test_report_written_to_output_dir(
+    sensitivity_config_path: Path, tmp_path: Path
+) -> None:
     """sensitivity_report.json is written to the output_dir path from config."""
     run_sensitivity(sensitivity_config_path)
     report_path = tmp_path / "outputs" / "sensitivity_report.json"
@@ -187,7 +198,9 @@ def test_method_both_produces_sobol_and_morris(tmp_path: Path) -> None:
     """method=both produces both sobol and morris blocks in report."""
     cfg_path = _write_config(tmp_path, method="both")
     run_sensitivity(cfg_path)
-    report = json.loads((tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8"))
+    report = json.loads(
+        (tmp_path / "outputs" / "sensitivity_report.json").read_text(encoding="utf-8")
+    )
     assert "sobol" in report, "sobol block must be present for method=both"
     assert "morris" in report, "morris block must be present for method=both"
 

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -23,12 +23,18 @@ from terraflow.model import suitability_score, suitability_score_array
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _default_params(**overrides: object) -> ModelParams:
     base: dict[str, object] = dict(
-        v_min=0.0, v_max=255.0,
-        t_min=0.0, t_max=40.0,
-        r_min=0.0, r_max=300.0,
-        w_v=0.4, w_t=0.3, w_r=0.3,
+        v_min=0.0,
+        v_max=255.0,
+        t_min=0.0,
+        t_max=40.0,
+        r_min=0.0,
+        r_max=300.0,
+        w_v=0.4,
+        w_t=0.3,
+        w_r=0.3,
     )
     base.update(overrides)
     return ModelParams(**base)  # type: ignore[arg-type]
@@ -120,6 +126,7 @@ def _write_linear_config(
 # suitability_score_array unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestSuitabilityScoreArray:
     def test_scalar_equivalence(self):
         """suitability_score_array should match suitability_score element-wise."""
@@ -129,7 +136,10 @@ class TestSuitabilityScoreArray:
         r = np.array([50.0, 150.0, 250.0])
 
         arr_result = suitability_score_array(v, t, r, params)
-        scalar_results = [suitability_score(float(v[i]), float(t[i]), float(r[i]), params) for i in range(len(v))]
+        scalar_results = [
+            suitability_score(float(v[i]), float(t[i]), float(r[i]), params)
+            for i in range(len(v))
+        ]
 
         np.testing.assert_allclose(arr_result, scalar_results, atol=1e-12)
 
@@ -160,7 +170,9 @@ class TestSuitabilityScoreArray:
         t = np.array([20.0])
         r = np.array([150.0])
 
-        assert suitability_score_array(v_high, t, r, params) >= suitability_score_array(v_low, t, r, params)
+        assert suitability_score_array(v_high, t, r, params) >= suitability_score_array(
+            v_low, t, r, params
+        )
 
     def test_degenerate_range(self):
         """When v_min == v_max, vegetation contribution is 0."""
@@ -177,6 +189,7 @@ class TestSuitabilityScoreArray:
 # ---------------------------------------------------------------------------
 # Pipeline integration tests
 # ---------------------------------------------------------------------------
+
 
 class TestMCColumnsPresent:
     def test_ci_columns_in_features_parquet(
@@ -220,12 +233,12 @@ class TestMCColumnsPresent:
         )
         df = run_pipeline(cfg)
 
-        assert (df["score_ci_low"] <= df["score"] + 1e-9).all(), (
-            "score_ci_low must be <= point score"
-        )
-        assert (df["score_ci_high"] >= df["score"] - 1e-9).all(), (
-            "score_ci_high must be >= point score"
-        )
+        assert (
+            df["score_ci_low"] <= df["score"] + 1e-9
+        ).all(), "score_ci_low must be <= point score"
+        assert (
+            df["score_ci_high"] >= df["score"] - 1e-9
+        ).all(), "score_ci_high must be >= point score"
         assert (df["score_ci_low"] <= df["score_ci_high"]).all()
 
     def test_ci_columns_in_valid_range(
@@ -425,8 +438,11 @@ class TestMCEdgeCases:
         monkeypatch.setattr(ClimateInterpolator, "interpolate", _zero_std_interpolate)
 
         cfg_path = _write_kriging_config(
-            tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv_dense,
-            tmp_path / "out", uncertainty_samples=50,
+            tmp_path / "cfg.yml",
+            synthetic_raster,
+            synthetic_climate_csv_dense,
+            tmp_path / "out",
+            uncertainty_samples=50,
         )
         df = run_pipeline(cfg_path)
 
@@ -446,14 +462,17 @@ class TestMCEdgeCases:
         from terraflow.pipeline import run_pipeline
 
         cfg_path = _write_kriging_config(
-            tmp_path / "cfg.yml", synthetic_raster, synthetic_climate_csv_dense,
-            tmp_path / "out", uncertainty_samples=1,
+            tmp_path / "cfg.yml",
+            synthetic_raster,
+            synthetic_climate_csv_dense,
+            tmp_path / "out",
+            uncertainty_samples=1,
         )
         df = run_pipeline(cfg_path)
 
         assert "score_ci_low" in df.columns
         assert "score_ci_high" in df.columns
         ci_width = (df["score_ci_high"] - df["score_ci_low"]).abs()
-        assert ci_width.max() < 1e-9, (
-            f"CI width should be ~0 with 1 MC sample, got max={ci_width.max()}"
-        )
+        assert (
+            ci_width.max() < 1e-9
+        ), f"CI width should be ~0 with 1 MC sample, got max={ci_width.max()}"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,4 +1,5 @@
 """Tests for terraflow.validation module (Phase 3: Model Validation)."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -12,11 +13,48 @@ class TestSpatialBlockCV:
     def test_assign_block_ids_grid(self):
         """Block IDs assigned correctly for a regular grid."""
         # 16 points in a 4x4 grid → 4 blocks with n_blocks_side=2
-        lats = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0,
-                         2.0, 2.0, 3.0, 3.0, 2.0, 2.0, 3.0, 3.0])
-        lons = np.array([0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 2.0, 3.0,
-                         0.0, 1.0, 0.0, 1.0, 2.0, 3.0, 2.0, 3.0])
+        lats = np.array(
+            [
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                1.0,
+                1.0,
+                2.0,
+                2.0,
+                3.0,
+                3.0,
+                2.0,
+                2.0,
+                3.0,
+                3.0,
+            ]
+        )
+        lons = np.array(
+            [
+                0.0,
+                1.0,
+                0.0,
+                1.0,
+                2.0,
+                3.0,
+                2.0,
+                3.0,
+                0.0,
+                1.0,
+                0.0,
+                1.0,
+                2.0,
+                3.0,
+                2.0,
+                3.0,
+            ]
+        )
         from terraflow.validation import _assign_block_ids
+
         ids = _assign_block_ids(lats, lons, n_blocks_side=2)
         assert ids.shape == (16,)
         assert len(np.unique(ids)) >= 2
@@ -25,8 +63,9 @@ class TestSpatialBlockCV:
         """Spatial block CV returns a list of per-fold accuracy floats."""
         lats = np.linspace(0, 3, 20)
         lons = np.linspace(0, 3, 20)
-        labels = np.array(['low'] * 10 + ['high'] * 10)
+        labels = np.array(["low"] * 10 + ["high"] * 10)
         from terraflow.validation import _spatial_block_cv
+
         accs = _spatial_block_cv(lats, lons, labels, n_blocks_side=2, buffer_deg=0.1)
         assert isinstance(accs, list)
         assert all(0.0 <= a <= 1.0 for a in accs)
@@ -35,8 +74,9 @@ class TestSpatialBlockCV:
         """Fewer than 2 unique blocks returns empty list with warning."""
         lats = np.array([1.0, 1.0, 1.0])
         lons = np.array([1.0, 1.0, 1.0])
-        labels = np.array(['low', 'low', 'low'])
+        labels = np.array(["low", "low", "low"])
         from terraflow.validation import _spatial_block_cv
+
         accs = _spatial_block_cv(lats, lons, labels, n_blocks_side=2, buffer_deg=0.1)
         assert accs == []
 
@@ -46,47 +86,66 @@ class TestCohensKappa:
 
     def test_kappa_perfect_agreement(self):
         """Perfect agreement produces kappa = 1.0."""
-        cells_df = pd.DataFrame({
-            'lat': [0.0, 1.0, 2.0],
-            'lon': [0.0, 1.0, 2.0],
-            'label': ['low', 'medium', 'high'],
-        })
-        ref_df = pd.DataFrame({
-            'lat': [0.0, 1.0, 2.0],
-            'lon': [0.0, 1.0, 2.0],
-            'label': ['low', 'medium', 'high'],
-        })
+        cells_df = pd.DataFrame(
+            {
+                "lat": [0.0, 1.0, 2.0],
+                "lon": [0.0, 1.0, 2.0],
+                "label": ["low", "medium", "high"],
+            }
+        )
+        ref_df = pd.DataFrame(
+            {
+                "lat": [0.0, 1.0, 2.0],
+                "lon": [0.0, 1.0, 2.0],
+                "label": ["low", "medium", "high"],
+            }
+        )
         from terraflow.validation import _compute_kappa
+
         kappa = _compute_kappa(cells_df, ref_df)
         assert kappa == pytest.approx(1.0)
 
     def test_kappa_with_mismatch(self):
         """Partial mismatch produces 0 < kappa < 1."""
-        cells_df = pd.DataFrame({
-            'lat': [0.0, 1.0, 2.0, 3.0],
-            'lon': [0.0, 1.0, 2.0, 3.0],
-            'label': ['low', 'medium', 'high', 'low'],
-        })
-        ref_df = pd.DataFrame({
-            'lat': [0.0, 1.0, 2.0, 3.0],
-            'lon': [0.0, 1.0, 2.0, 3.0],
-            'label': ['low', 'medium', 'low', 'low'],
-        })
+        cells_df = pd.DataFrame(
+            {
+                "lat": [0.0, 1.0, 2.0, 3.0],
+                "lon": [0.0, 1.0, 2.0, 3.0],
+                "label": ["low", "medium", "high", "low"],
+            }
+        )
+        ref_df = pd.DataFrame(
+            {
+                "lat": [0.0, 1.0, 2.0, 3.0],
+                "lon": [0.0, 1.0, 2.0, 3.0],
+                "label": ["low", "medium", "low", "low"],
+            }
+        )
         from terraflow.validation import _compute_kappa
+
         kappa = _compute_kappa(cells_df, ref_df)
         assert -1.0 <= kappa <= 1.0
 
     def test_kappa_extent_warning(self):
         """Reference points far from cells emit a warning."""
-        cells_df = pd.DataFrame({
-            'lat': [0.0], 'lon': [0.0], 'label': ['low'],
-        })
-        ref_df = pd.DataFrame({
-            'lat': [50.0], 'lon': [50.0], 'label': ['low'],
-        })
+        cells_df = pd.DataFrame(
+            {
+                "lat": [0.0],
+                "lon": [0.0],
+                "label": ["low"],
+            }
+        )
+        ref_df = pd.DataFrame(
+            {
+                "lat": [50.0],
+                "lon": [50.0],
+                "label": ["low"],
+            }
+        )
         import warnings
 
         from terraflow.validation import _compute_kappa
+
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             _compute_kappa(cells_df, ref_df)
@@ -102,6 +161,7 @@ class TestMoransI:
         lons = np.array([0.0, 0.1, 0.2, 3.0, 3.1, 3.2])
         residuals = np.array([1.0, 1.1, 0.9, -1.0, -0.9, -1.1])
         from terraflow.validation import _morans_i
+
         moran_stat = _morans_i(lats, lons, residuals)
         assert moran_stat is not None
         assert moran_stat > 0.0
@@ -112,6 +172,7 @@ class TestMoransI:
         lons = np.array([0.0, 1.0, 2.0])
         residuals = np.array([5.0, 5.0, 5.0])
         from terraflow.validation import _morans_i
+
         moran_stat = _morans_i(lats, lons, residuals)
         assert moran_stat is None
 
@@ -122,6 +183,7 @@ class TestReportValidationBlock:
     def test_validation_block_has_required_keys(self):
         """Validation block contains kappa, morans_i, mean_fold_accuracy."""
         from terraflow.validation import run_validation
+
         assert callable(run_validation)
 
 
@@ -156,15 +218,18 @@ _MINIMAL_CONFIG_WITH_REF = _MINIMAL_CONFIG.rstrip() + "\n  reference_csv: {ref_c
 def _make_features_parquet(run_dir, n=30):
     """Write a minimal features.parquet into run_dir."""
     import pandas as pd
+
     rng = np.random.default_rng(42)
-    df = pd.DataFrame({
-        "lat": np.linspace(0.0, 3.0, n),
-        "lon": np.linspace(0.0, 3.0, n),
-        "score": rng.uniform(0.2, 0.9, n),
-        "label": np.where(np.linspace(0.0, 3.0, n) > 1.5, "high", "low"),
-        "cell_id": np.arange(n),
-        "run_id": ["test"] * n,
-    })
+    df = pd.DataFrame(
+        {
+            "lat": np.linspace(0.0, 3.0, n),
+            "lon": np.linspace(0.0, 3.0, n),
+            "score": rng.uniform(0.2, 0.9, n),
+            "label": np.where(np.linspace(0.0, 3.0, n) > 1.5, "high", "low"),
+            "cell_id": np.arange(n),
+            "run_id": ["test"] * n,
+        }
+    )
     run_dir.mkdir(parents=True, exist_ok=True)
     df.to_parquet(run_dir / "features.parquet", index=False)
     return df
@@ -191,8 +256,15 @@ class TestRunValidation:
 
         assert result.exists()
         block = json.loads(result.read_text())["validation"]
-        for key in ("method", "n_folds", "mean_fold_accuracy", "cohen_kappa",
-                    "morans_i_residuals", "n_blocks_side", "buffer_deg"):
+        for key in (
+            "method",
+            "n_folds",
+            "mean_fold_accuracy",
+            "cohen_kappa",
+            "morans_i_residuals",
+            "n_blocks_side",
+            "buffer_deg",
+        ):
             assert key in block, f"missing key: {key}"
 
     def test_run_validation_merges_existing_report(self, tmp_path):
@@ -204,7 +276,9 @@ class TestRunValidation:
 
         run_dir = tmp_path / "runs" / "abc123"
         _make_features_parquet(run_dir)
-        (run_dir / "report.json").write_text(json.dumps({"run_id": "abc123", "timings": {"total_s": 1.5}}))
+        (run_dir / "report.json").write_text(
+            json.dumps({"run_id": "abc123", "timings": {"total_s": 1.5}})
+        )
 
         cfg_path = tmp_path / "config.yml"
         cfg_path.write_text(_MINIMAL_CONFIG.format(out_dir=tmp_path))
@@ -262,14 +336,18 @@ class TestRunValidation:
         df = _make_features_parquet(run_dir)
 
         ref_csv = tmp_path / "ref.csv"
-        pd.DataFrame({
-            "lat": df["lat"].values[:10],
-            "lon": df["lon"].values[:10],
-            "label": df["label"].values[:10],
-        }).to_csv(ref_csv, index=False)
+        pd.DataFrame(
+            {
+                "lat": df["lat"].values[:10],
+                "lon": df["lon"].values[:10],
+                "label": df["label"].values[:10],
+            }
+        ).to_csv(ref_csv, index=False)
 
         cfg_path = tmp_path / "config.yml"
-        cfg_path.write_text(_MINIMAL_CONFIG_WITH_REF.format(out_dir=tmp_path, ref_csv=ref_csv))
+        cfg_path.write_text(
+            _MINIMAL_CONFIG_WITH_REF.format(out_dir=tmp_path, ref_csv=ref_csv)
+        )
 
         with patch("terraflow.validation.resolve_run_dir", return_value=run_dir):
             result = run_validation(cfg_path)


### PR DESCRIPTION
## Summary

- Closed 5 resolved issues (#60, #61, #62, #63, #40) — implemented in prior phases but never closed
- Removed excessive comments from pipeline.py, ingest.py, geo.py, climate.py — comments now only at genuinely complex logic
- Refactored run_pipeline() from 425 lines to ~130 lines of orchestration by extracting _project_cells_to_wgs84, _score_cells, _apply_monte_carlo, _build_report — reduces cognitive complexity below SonarQube threshold
- Fixed import math inline-in-function in geo.py — moved to module level
- Updated docs/architecture/overview.md — reflects v0.2.2 state with all modules, correct artifact paths, H3 export
- Updated CLAUDE.md — module map includes export.py and ExportConfig; version bumped to 0.2.2

## Test plan

- [x] make test — 209 passed, 3 skipped
- [x] make lint — ruff + black clean
- [x] make typecheck — mypy clean
- [x] Closed issues verified implemented in codebase before closing

🤖 Generated with [Claude Code](https://claude.com/claude-code)