### PR TITLE
[codex] address issues #35 and #36

### DIFF
--- a/docs/config/examples.md
+++ b/docs/config/examples.md
@@ -66,9 +66,12 @@ model_params:
 climate:
   strategy: spatial
   interpolation_method: kriging
+  variogram_mode: standard
   fallback_to_mean: true
 max_cells: 250
 ```
+
+Set `variogram_mode: extended` when you want TerraFlow to try additional nested variogram candidates before selecting the best kriging model.
 
 ## IDW (fast, no uncertainty)
 

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -116,6 +116,7 @@ Climate data is applied ==per-cell== using configurable interpolation strategies
 |---|---|---|---|
 | `strategy` | string | `"spatial"` | `"spatial"` or `"index"` — how cells are matched to climate observations |
 | `interpolation_method` | string | `"linear"` | `"linear"`, `"kriging"`, or `"idw"` — spatial algorithm (ignored when `strategy: index`) |
+| `variogram_mode` | string | `"standard"` | `"standard"` tries spherical/exponential/Gaussian; `"extended"` also evaluates nested kriging candidates (kriging only) |
 | `fallback_to_mean` | bool | `true` | Use global mean for cells outside interpolation range |
 | `cell_id_column` | string | `null` | Column for explicit cell ID matching (index strategy only) |
 
@@ -141,11 +142,14 @@ Climate data is applied ==per-cell== using configurable interpolation strategies
     climate:
       strategy: spatial
       interpolation_method: kriging
+      variogram_mode: standard
       fallback_to_mean: true
     model_params:
       # ... other params ...
       uncertainty_samples: 500  # produces score_ci_low / score_ci_high
     ```
+
+    Set `variogram_mode: extended` to evaluate additional nested candidates and record their LOOCV scores in `report.json`.
 
     !!! note "Requires pykrige"
         Install with `pip install terraflow-agro[kriging]` or `pip install pykrige`.
@@ -187,4 +191,4 @@ lat,lon,mean_temp,total_rain
 - **`lon`**: Longitude in [-180, 180]
 - **Climate variables**: One or more numeric columns (`mean_temp`, `total_rain`, etc.)
 
-If `climate` is omitted entirely, defaults to `strategy: spatial`, `interpolation_method: linear`, `fallback_to_mean: true`.
+If `climate` is omitted entirely, defaults to `strategy: spatial`, `interpolation_method: linear`, `variogram_mode: standard`, `fallback_to_mean: true`.

--- a/terraflow/climate.py
+++ b/terraflow/climate.py
@@ -44,7 +44,7 @@ Example
 from __future__ import annotations
 
 import logging
-from typing import Dict, Literal, Optional, Tuple
+from typing import Callable, Dict, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -61,6 +61,49 @@ MIN_KRIGING_STATIONS: int = 5
 
 #: Variogram models tried during automatic model selection.
 _VARIOGRAM_MODELS: Tuple[str, ...] = ("spherical", "exponential", "gaussian")
+
+
+def _nested_spherical_gaussian_variogram(m: np.ndarray, d: np.ndarray) -> np.ndarray:
+    psill_sph, range_sph, psill_gau, range_gau, nugget = m
+    d = np.asarray(d, dtype=float)
+    gamma = np.full_like(d, float(nugget), dtype=float)
+
+    safe_range_sph = max(float(range_sph), 1e-12)
+    h = d / safe_range_sph
+    spherical = np.where(
+        d <= safe_range_sph,
+        float(psill_sph) * (1.5 * h - 0.5 * h**3),
+        float(psill_sph),
+    )
+
+    safe_range_gau = max(float(range_gau), 1e-12)
+    gaussian = float(psill_gau) * (
+        1.0 - np.exp(-(d**2) / ((safe_range_gau * 4.0 / 7.0) ** 2))
+    )
+    return gamma + spherical + gaussian
+
+
+def _nested_exponential_gaussian_variogram(
+    m: np.ndarray, d: np.ndarray
+) -> np.ndarray:
+    psill_exp, range_exp, psill_gau, range_gau, nugget = m
+    d = np.asarray(d, dtype=float)
+
+    safe_range_exp = max(float(range_exp), 1e-12)
+    safe_range_gau = max(float(range_gau), 1e-12)
+    exponential = float(psill_exp) * (
+        1.0 - np.exp(-d / (safe_range_exp / 3.0))
+    )
+    gaussian = float(psill_gau) * (
+        1.0 - np.exp(-(d**2) / ((safe_range_gau * 4.0 / 7.0) ** 2))
+    )
+    return float(nugget) + exponential + gaussian
+
+
+_NESTED_VARIAGRAM_FUNCTIONS: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = {
+    "nested_spherical_gaussian": _nested_spherical_gaussian_variogram,
+    "nested_exponential_gaussian": _nested_exponential_gaussian_variogram,
+}
 
 
 class CoordinateRange(BaseModel):
@@ -141,6 +184,7 @@ class ClimateInterpolator:
         climate_df: pd.DataFrame,
         strategy: Literal["spatial", "index"] = "spatial",
         interpolation_method: Literal["linear", "kriging", "idw"] = "linear",
+        variogram_mode: Literal["standard", "extended"] = "standard",
         cell_id_column: Optional[str] = None,
         fallback_to_mean: bool = True,
     ):
@@ -179,15 +223,28 @@ class ClimateInterpolator:
                 f"interpolation_method must be 'linear', 'kriging', or 'idw', "
                 f"got '{interpolation_method}'"
             )
+        if variogram_mode not in ("standard", "extended"):
+            raise ValueError(
+                f"variogram_mode must be 'standard' or 'extended', got '{variogram_mode}'"
+            )
+        if interpolation_method != "kriging" and variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when interpolation_method='kriging'"
+            )
 
         self.climate_df = climate_df.copy()
         self.strategy = strategy
         self.interpolation_method = interpolation_method
+        self.variogram_mode = variogram_mode
         self.cell_id_column = cell_id_column
         self.fallback_to_mean = fallback_to_mean
         self.cv_metrics: Dict = {}
         self._krig_variogram_model: str = "spherical"  # overwritten by _init_kriging
         self.variogram_params: dict = {}
+        self._krig_variogram_parameters: Optional[Tuple[float, ...]] = None
+        self._krig_variogram_function: Optional[
+            Callable[[np.ndarray, np.ndarray], np.ndarray]
+        ] = None
 
         self._validate_columns()
 
@@ -201,12 +258,88 @@ class ClimateInterpolator:
 
         logger.info(
             f"ClimateInterpolator initialised: strategy='{strategy}', "
-            f"interpolation_method='{interpolation_method}', records={len(self.climate_df)}, variables={self.climate_columns}"
+            f"interpolation_method='{interpolation_method}', variogram_mode='{variogram_mode}', "
+            f"records={len(self.climate_df)}, variables={self.climate_columns}"
         )
 
-    # ------------------------------------------------------------------
-    # Initialisation helpers
-    # ------------------------------------------------------------------
+    def _candidate_model_names(self) -> Tuple[str, ...]:
+        if self.variogram_mode == "extended":
+            return _VARIOGRAM_MODELS + tuple(_NESTED_VARIAGRAM_FUNCTIONS.keys())
+        return _VARIOGRAM_MODELS
+
+    def _build_ok(
+        self,
+        lons: np.ndarray,
+        lats: np.ndarray,
+        vals: np.ndarray,
+        model_name: str,
+        variogram_parameters: Optional[Tuple[float, ...]] = None,
+    ):
+        from pykrige.ok import OrdinaryKriging
+
+        kwargs = {
+            "verbose": False,
+            "enable_plotting": False,
+        }
+        if model_name in _NESTED_VARIAGRAM_FUNCTIONS:
+            kwargs.update(
+                {
+                    "variogram_model": "custom",
+                    "variogram_parameters": (
+                        list(variogram_parameters)
+                        if variogram_parameters is not None
+                        else None
+                    ),
+                    "variogram_function": _NESTED_VARIAGRAM_FUNCTIONS[model_name],
+                }
+            )
+        else:
+            kwargs["variogram_model"] = model_name
+            if variogram_parameters is not None:
+                kwargs["variogram_parameters"] = variogram_parameters
+        return OrdinaryKriging(lons, lats, vals, **kwargs)
+
+    def _fit_nested_variogram(
+        self, lons: np.ndarray, lats: np.ndarray, vals: np.ndarray, model_name: str
+    ) -> Tuple[float, ...]:
+        from scipy.optimize import curve_fit
+
+        probe = self._build_ok(lons, lats, vals, "spherical")
+        lags = np.asarray(probe.lags, dtype=float)
+        semivariance = np.asarray(probe.semivariance, dtype=float)
+        if lags.size == 0 or semivariance.size == 0:
+            raise ValueError("No empirical semivariogram points available")
+
+        max_lag = float(max(np.nanmax(lags), 1e-6))
+        sill_guess = float(max(np.nanmax(semivariance), 1e-6))
+        nugget_guess = float(max(np.nanmin(semivariance), 0.0))
+        psill_total = max(sill_guess - nugget_guess, 1e-6)
+        initial = np.array(
+            [
+                psill_total * 0.6,
+                max_lag / 3.0,
+                psill_total * 0.4,
+                max_lag * 0.75,
+                nugget_guess,
+            ],
+            dtype=float,
+        )
+        lower = np.array([1e-9, 1e-9, 1e-9, 1e-9, 0.0], dtype=float)
+        upper = np.array(
+            [sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0],
+            dtype=float,
+        )
+
+        variogram_fn = _NESTED_VARIAGRAM_FUNCTIONS[model_name]
+        params, _ = curve_fit(
+            lambda dist, *m: variogram_fn(np.asarray(m, dtype=float), dist),
+            lags,
+            semivariance,
+            p0=initial,
+            bounds=(lower, upper),
+            maxfev=20000,
+        )
+        return tuple(float(p) for p in params)
 
     def _validate_columns(self) -> None:
         """Validate that climate data has required columns."""
@@ -240,7 +373,9 @@ class ClimateInterpolator:
 
         nan_count = lats.isna().sum() + lons.isna().sum()
         if nan_count > 0:
-            logger.warning(f"Found {nan_count} NaN values in lat/lon coordinates. Removing rows with missing coordinates.")
+            logger.warning(
+                f"Found {nan_count} NaN values in lat/lon coordinates. Removing rows with missing coordinates."
+            )
             self.climate_df = self.climate_df.dropna(subset=["lat", "lon"])
 
         lat_min, lat_max = lats.min(), lats.max()
@@ -261,19 +396,19 @@ class ClimateInterpolator:
             try:
                 CoordinateRange(latitude=lat, longitude=lon)
             except ValueError as e:
-                raise ValueError(f"Row {idx}: Invalid coordinate ({lat}, {lon}): {e}") from e
+                raise ValueError(
+                    f"Row {idx}: Invalid coordinate ({lat}, {lon}): {e}"
+                ) from e
 
         duplicates = self.climate_df.duplicated(subset=["lat", "lon"], keep=False).sum()
         if duplicates > 0:
-            logger.warning(f"Found {duplicates} duplicate lat/lon coordinates in climate data. Interpolation may produce ambiguous results.")
+            logger.warning(
+                f"Found {duplicates} duplicate lat/lon coordinates in climate data. Interpolation may produce ambiguous results."
+            )
 
     def _compute_mean_climate(self) -> dict:
         """Cache mean values of each climate variable for fallback use."""
         return {col: float(self.climate_df[col].mean()) for col in self.climate_columns}
-
-    # ------------------------------------------------------------------
-    # Kriging initialisation: variogram selection + LOOCV
-    # ------------------------------------------------------------------
 
     def _init_kriging(self) -> None:
         """Select the best variogram model via LOOCV and compute CV metrics.
@@ -305,22 +440,37 @@ class ClimateInterpolator:
         lons = self.climate_df["lon"].values.astype(float)
         lats = self.climate_df["lat"].values.astype(float)
 
-        # --- Variogram model selection on the first climate variable ----------
         primary_var = self.climate_columns[0]
         vals_primary = self.climate_df[primary_var].values.astype(float)
 
         best_model: Optional[str] = None
+        best_model_params: Optional[Tuple[float, ...]] = None
         best_rmse = np.inf
+        candidate_scores: Dict[str, Dict[str, float]] = {}
 
-        for model in _VARIOGRAM_MODELS:
+        for model in self._candidate_model_names():
             try:
-                rmse, _ = self._loocv(lons, lats, vals_primary, model)
-                logger.debug(f"Variogram '{model}': LOOCV RMSE={rmse:.4f} ({primary_var})")
+                rmse, mae = self._loocv(lons, lats, vals_primary, model)
+                candidate_scores[model] = {
+                    "rmse": round(float(rmse), 6),
+                    "mae": round(float(mae), 6),
+                }
+                logger.debug(
+                    f"Variogram '{model}': LOOCV RMSE={rmse:.4f} ({primary_var})"
+                )
                 if rmse < best_rmse:
                     best_rmse = rmse
                     best_model = model
+                    if model in _NESTED_VARIAGRAM_FUNCTIONS:
+                        best_model_params = self._fit_nested_variogram(
+                            lons, lats, vals_primary, model
+                        )
+                    else:
+                        best_model_params = None
             except (ValueError, RuntimeError, np.linalg.LinAlgError) as exc:
-                logger.debug(f"Variogram model '{model}' failed during selection: {exc}")
+                logger.debug(
+                    f"Variogram model '{model}' failed during selection: {exc}"
+                )
 
         if best_model is None:
             logger.warning(
@@ -330,28 +480,32 @@ class ClimateInterpolator:
             return
 
         self._krig_variogram_model = best_model
-        logger.info(f"Kriging variogram selected: '{best_model}' (LOOCV RMSE={best_rmse:.4f} for '{primary_var}')")
-
-        # Extract variogram parameters from a full-data fit with the selected model.
-        from pykrige.ok import OrdinaryKriging
-
-        _ok_full = OrdinaryKriging(
-            lons, lats, vals_primary,
-            variogram_model=best_model,
-            verbose=False,
-            enable_plotting=False,
+        self._krig_variogram_parameters = best_model_params
+        self._krig_variogram_function = _NESTED_VARIAGRAM_FUNCTIONS.get(best_model)
+        logger.info(
+            f"Kriging variogram selected: '{best_model}' (LOOCV RMSE={best_rmse:.4f} for '{primary_var}')"
         )
-        p = _ok_full.variogram_model_parameters  # [psill, range, nugget]
+
+        _ok_full = self._build_ok(
+            lons, lats, vals_primary, best_model, best_model_params
+        )
+        p = tuple(float(x) for x in _ok_full.variogram_model_parameters)
         self.variogram_params = {
             "model": best_model,
-            "psill": round(float(p[0]), 6),
-            "nugget": round(float(p[2]), 6),
-            "sill": round(float(p[0]) + float(p[2]), 6),
-            "range_": round(float(p[1]), 6),
+            "mode": self.variogram_mode,
+            "parameters": [round(x, 6) for x in p],
             "range_units": "degrees_geographic",
         }
+        if best_model not in _NESTED_VARIAGRAM_FUNCTIONS and len(p) >= 3:
+            self.variogram_params.update(
+                {
+                    "psill": round(float(p[0]), 6),
+                    "nugget": round(float(p[2]), 6),
+                    "sill": round(float(p[0]) + float(p[2]), 6),
+                    "range_": round(float(p[1]), 6),
+                }
+            )
 
-        # --- Full LOOCV for all variables with the selected model -------------
         cv_per_var: Dict = {}
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
@@ -369,6 +523,8 @@ class ClimateInterpolator:
         self.cv_metrics = {
             "method": "loocv",
             "variogram_model": best_model,
+            "variogram_mode": self.variogram_mode,
+            "candidate_scores": candidate_scores,
             "per_variable": cv_per_var,
         }
 
@@ -376,26 +532,21 @@ class ClimateInterpolator:
         self, lons: np.ndarray, lats: np.ndarray, vals: np.ndarray, model: str
     ) -> Tuple[float, float]:
         """Return (RMSE, MAE) via Leave-One-Out Cross-Validation for a variogram model."""
-        from pykrige.ok import OrdinaryKriging
-
         errors = []
         for i in range(len(vals)):
-            ok = OrdinaryKriging(
-                np.delete(lons, i),
-                np.delete(lats, i),
-                np.delete(vals, i),
-                variogram_model=model,
-                verbose=False,
-                enable_plotting=False,
-            )
+            train_lons = np.delete(lons, i)
+            train_lats = np.delete(lats, i)
+            train_vals = np.delete(vals, i)
+            params = None
+            if model in _NESTED_VARIAGRAM_FUNCTIONS:
+                params = self._fit_nested_variogram(
+                    train_lons, train_lats, train_vals, model
+                )
+            ok = self._build_ok(train_lons, train_lats, train_vals, model, params)
             pred, _ = ok.execute("points", np.array([lons[i]]), np.array([lats[i]]))
             errors.append(float(pred[0]) - vals[i])
         errs = np.array(errors)
         return float(np.sqrt(np.mean(errs**2))), float(np.mean(np.abs(errs)))
-
-    # ------------------------------------------------------------------
-    # Public interface
-    # ------------------------------------------------------------------
 
     def interpolate(self, cell_lats: np.ndarray, cell_lons: np.ndarray) -> pd.DataFrame:
         """Interpolate or match climate data to cell locations.
@@ -434,10 +585,6 @@ class ClimateInterpolator:
         else:
             return self._match_by_index(cell_lats, cell_lons)
 
-    # ------------------------------------------------------------------
-    # Spatial interpolation dispatch
-    # ------------------------------------------------------------------
-
     def _interpolate_spatial(
         self, cell_lats: np.ndarray, cell_lons: np.ndarray
     ) -> pd.DataFrame:
@@ -473,7 +620,9 @@ class ClimateInterpolator:
                     fill_value=np.nan,
                 )
             except (ValueError, RuntimeError) as exc:
-                logger.info(f"Linear interpolation failed ({exc}), falling back to nearest-neighbor")
+                logger.info(
+                    f"Linear interpolation failed ({exc}), falling back to nearest-neighbor"
+                )
                 interp_values = griddata(
                     climate_points,
                     values,
@@ -486,7 +635,9 @@ class ClimateInterpolator:
                 nan_mask = np.isnan(interp_values)
                 if nan_mask.any():
                     interp_values[nan_mask] = self._climate_mean[col]
-                    logger.info(f"Filled {nan_mask.sum()} cells with mean {col} ({self._climate_mean[col]:.3f}) due to extrapolation")
+                    logger.info(
+                        f"Filled {nan_mask.sum()} cells with mean {col} ({self._climate_mean[col]:.3f}) due to extrapolation"
+                    )
             result[col] = interp_values
 
         return pd.DataFrame(result)
@@ -511,13 +662,12 @@ class ClimateInterpolator:
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
 
-            ok = OrdinaryKriging(
+            ok = self._build_ok(
                 lons_src,
                 lats_src,
                 vals,
-                variogram_model=self._krig_variogram_model,
-                verbose=False,
-                enable_plotting=False,
+                self._krig_variogram_model,
+                self._krig_variogram_parameters,
             )
             z_pred, sigma_sq = ok.execute("points", cell_lons_arr, cell_lats_arr)
 
@@ -529,7 +679,9 @@ class ClimateInterpolator:
                 nan_mask = np.isnan(z_pred_arr)
                 if nan_mask.any():
                     z_pred_arr[nan_mask] = self._climate_mean[var]
-                    logger.info(f"Filled {nan_mask.sum()} NaN kriging predictions with mean {var}")
+                    logger.info(
+                        f"Filled {nan_mask.sum()} NaN kriging predictions with mean {var}"
+                    )
 
             result[var] = z_pred_arr
             result[f"{var}_krig_std"] = krig_std
@@ -561,7 +713,7 @@ class ClimateInterpolator:
                     # Cell coincides with a station — return exact value
                     interp_values[i] = vals[np.argmax(zero_mask)]
                 else:
-                    weights = 1.0 / (dists ** power)
+                    weights = 1.0 / (dists**power)
                     interp_values[i] = np.sum(weights * vals) / np.sum(weights)
 
             if self.fallback_to_mean:
@@ -572,10 +724,6 @@ class ClimateInterpolator:
             result[var] = interp_values
 
         return pd.DataFrame(result)
-
-    # ------------------------------------------------------------------
-    # Index-based matching
-    # ------------------------------------------------------------------
 
     def _match_by_index(
         self, cell_lats: np.ndarray, _cell_lons: np.ndarray
@@ -605,7 +753,9 @@ class ClimateInterpolator:
                         f"ensure climate CSV has at least {n_cells} rows."
                     )
             elif n_climate > n_cells:
-                logger.info(f"Climate records ({n_climate}) > cells ({n_cells}). Using first {n_cells} records.")
+                logger.info(
+                    f"Climate records ({n_climate}) > cells ({n_cells}). Using first {n_cells} records."
+                )
                 return self.climate_df[self.climate_columns].head(n_cells).copy()
             else:
                 return self.climate_df[self.climate_columns].copy()
@@ -615,5 +765,7 @@ class ClimateInterpolator:
                     f"cell_id_column '{self.cell_id_column}' not found in climate_df. "
                     f"Available columns: {list(self.climate_df.columns)}"
                 )
-            logger.info(f"Index-based matching using cell_id_column='{self.cell_id_column}'")
+            logger.info(
+                f"Index-based matching using cell_id_column='{self.cell_id_column}'"
+            )
             return self.climate_df[self.climate_columns].copy()

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -157,6 +157,7 @@ class ClimateConfig(BaseModel):
 
     strategy: Literal["spatial", "index"] = "spatial"
     interpolation_method: Literal["linear", "kriging", "idw"] = "linear"
+    variogram_mode: Literal["standard", "extended"] = "standard"
     cell_id_column: str | None = None
     fallback_to_mean: bool = True
 
@@ -180,10 +181,26 @@ class ClimateConfig(BaseModel):
             )
         return v
 
+    @field_validator("variogram_mode")
+    @classmethod
+    def validate_variogram_mode(cls, v: str) -> str:
+        """Ensure variogram_mode is valid."""
+        if v not in ("standard", "extended"):
+            raise ValueError(
+                f"variogram_mode must be 'standard' or 'extended', got '{v}'"
+            )
+        return v
+
     def validate_config(self) -> None:
         """Validate consistency of climate configuration."""
-        # interpolation_method only applies to spatial strategy
-        pass
+        if self.strategy != "spatial" and self.variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when climate.strategy='spatial'"
+            )
+        if self.interpolation_method != "kriging" and self.variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when interpolation_method='kriging'"
+            )
 
 
 class WeightBounds(BaseModel):
@@ -284,7 +301,9 @@ class PipelineConfig(BaseModel):
     model_params: ModelParams
     climate: ClimateConfig = ClimateConfig()  # Default: spatial strategy with fallback
     max_cells: int = 500  # maximum number of cells to sample from the ROI
-    sensitivity: Optional[SensitivityConfig] = None  # Optional sensitivity analysis config
+    sensitivity: Optional[SensitivityConfig] = (
+        None  # Optional sensitivity analysis config
+    )
     validation: Optional[ValidationConfig] = None  # Optional validation config
     export: Optional[ExportConfig] = None  # Optional H3 export config
 

--- a/terraflow/geo.py
+++ b/terraflow/geo.py
@@ -1,9 +1,11 @@
+import math
 from typing import Any, Dict, Tuple
 
 import numpy as np
 import rasterio
 from pyproj import Transformer
 from rasterio.crs import CRS
+from rasterio.errors import WindowError
 from rasterio.io import DatasetReader
 from rasterio.windows import Window, from_bounds
 
@@ -44,11 +46,9 @@ def clip_raster_to_roi(
         If raster does not have band 1, ROI bounds are invalid, or the
         (reprojected) ROI does not intersect the raster extent.
     """
-    # Validate that band 1 exists
     if raster.count < 1:
         raise ValueError("Raster has no bands. Cannot read band 1.")
 
-    # Validate ROI bounds before any reprojection
     if roi["xmin"] >= roi["xmax"] or roi["ymin"] >= roi["ymax"]:
         raise ValueError(
             f"Invalid ROI bounds: xmin={roi['xmin']}, xmax={roi['xmax']}, "
@@ -58,7 +58,6 @@ def clip_raster_to_roi(
 
     xmin, ymin, xmax, ymax = roi["xmin"], roi["ymin"], roi["xmax"], roi["ymax"]
 
-    # Reproject ROI bounds to raster CRS when they differ.
     raster_crs = raster.crs
     src_crs = CRS.from_user_input(roi_crs)
     if src_crs != raster_crs:
@@ -74,11 +73,8 @@ def clip_raster_to_roi(
             f"xmin={xmin:.2f} ymin={ymin:.2f} xmax={xmax:.2f} ymax={ymax:.2f}"
         )
 
-    # Compute rasterio window from the (reprojected) bounds.
     try:
-        window: Window = from_bounds(
-            xmin, ymin, xmax, ymax, transform=raster.transform
-        )
+        window: Window = from_bounds(xmin, ymin, xmax, ymax, transform=raster.transform)
     except Exception as e:
         raise ValueError(
             f"Could not compute raster window for ROI bounds "
@@ -89,7 +85,6 @@ def clip_raster_to_roi(
     # Guard against degenerate windows (NaN dimensions) that arise when
     # reprojected bounds are numerically invalid (e.g. coordinates outside
     # the valid domain of the target CRS).
-    import math
     if math.isnan(window.width) or math.isnan(window.height):
         raise ValueError(
             f"ROI bounds ({xmin}, {ymin}, {xmax}, {ymax}) produced a "
@@ -98,7 +93,18 @@ def clip_raster_to_roi(
             f"coordinates are valid in that CRS."
         )
 
-    # Read the windowed data.
+    # Snap to pixel boundaries and clamp to the raster extent so small ROIs
+    # read only the intersecting window instead of an oversized float window.
+    full_window = Window(col_off=0, row_off=0, width=raster.width, height=raster.height)
+    try:
+        window = window.round_offsets().round_lengths().intersection(full_window)
+    except WindowError as e:
+        raise ValueError(
+            f"ROI does not intersect the raster (raster extent: {raster.bounds}). "
+            f"Verify that roi_crs='{roi_crs}' matches the coordinate system of "
+            f"your xmin/ymin/xmax/ymax values."
+        ) from e
+
     data = raster.read(1, window=window, masked=True)
     transform = raster.window_transform(window)
 

--- a/terraflow/pipeline.py
+++ b/terraflow/pipeline.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+import rasterio
 from pyproj import Transformer
 from pyproj.exceptions import CRSError as _PyProjCRSError
 from rasterio.crs import CRS
@@ -49,37 +50,22 @@ from .ingest import build_data_catalog, load_climate_csv, load_raster
 from .model import suitability_label, suitability_score, suitability_score_array
 from .utils import ensure_dir, logger
 
-# ---------------------------------------------------------------------------
-# Schema contract
-# ---------------------------------------------------------------------------
-
 #: Tidy/wide schema for features.parquet (v1).
-#:
-#: Rationale for wide format: each *row* is one sampled cell (the natural
-#: observation unit); each *column* is one feature.  This matches the output
-#: contract of rasterstats, GeoPandas zonal_stats, and standard GIS tool
-#: pipelines.  Adding new climate variables in future releases appends columns
-#: and is backward-compatible via nullable columns.  The ``run_id`` column
-#: allows joining across runs and multi-run longitudinal datasets.
 FEATURES_SCHEMA_VERSION = "1"
 FEATURES_COLUMNS_ORDERED = [
-    "run_id",       # str   — run_fingerprint (links to manifest.json)
-    "cell_id",      # int64 — 0-based sampled-cell index (stable within a run)
-    "lat",          # float64 — WGS84 latitude (degrees N), always geographic
-    "lon",          # float64 — WGS84 longitude (degrees E), always geographic
-    "v_index",      # float64 — raster band-1 value (vegetation/crop index)
-    "mean_temp",    # float64 — interpolated mean temperature (°C)
-    "total_rain",   # float64 — interpolated total rainfall (mm)
-    "score",        # float64 — composite suitability score in [0.0, 1.0]
-    "label",        # str    — categorical: "low" / "medium" / "high"
+    "run_id",  # str   — run_fingerprint (links to manifest.json)
+    "cell_id",  # int64 — 0-based sampled-cell index (stable within a run)
+    "lat",  # float64 — WGS84 latitude (degrees N), always geographic
+    "lon",  # float64 — WGS84 longitude (degrees E), always geographic
+    "v_index",  # float64 — raster band-1 value (vegetation/crop index)
+    "mean_temp",  # float64 — interpolated mean temperature (°C)
+    "total_rain",  # float64 — interpolated total rainfall (mm)
+    "score",  # float64 — composite suitability score in [0.0, 1.0]
+    "label",  # str    — categorical: "low" / "medium" / "high"
 ]
 
 MANIFEST_SCHEMA_VERSION = "1"
 REPORT_SCHEMA_VERSION = "1"
-
-# ---------------------------------------------------------------------------
-# Internal helpers — path resolution
-# ---------------------------------------------------------------------------
 
 
 def _expand_input_paths(path_value: str, config_dir: Path) -> List[Path]:
@@ -193,11 +179,6 @@ def _resolve_roi_hash(config_dict: dict, config_dir: Path) -> str:
     raise ValueError("ROI configuration missing or unsupported")
 
 
-# ---------------------------------------------------------------------------
-# Public helper — locate a run directory by fingerprint
-# ---------------------------------------------------------------------------
-
-
 def resolve_run_dir(config_path: Path | str) -> Path:
     """Return the run directory for a given config without running the pipeline.
 
@@ -236,11 +217,6 @@ def resolve_run_dir(config_path: Path | str) -> Path:
     return output_dir / "runs" / run_fingerprint
 
 
-# ---------------------------------------------------------------------------
-# Deprecated helper (kept for backward-compat; used by existing tests)
-# ---------------------------------------------------------------------------
-
-
 def _aggregate_climate(climate_df: pd.DataFrame) -> Dict[str, float]:
     """
     Aggregate climate data into simple summary statistics (deprecated).
@@ -266,11 +242,6 @@ def _aggregate_climate(climate_df: pd.DataFrame) -> Dict[str, float]:
     return result
 
 
-# ---------------------------------------------------------------------------
-# Atomic I/O helpers
-# ---------------------------------------------------------------------------
-
-
 def _atomic_write_text(path: Path, content: str) -> None:
     """Write *content* to *path* atomically (write-to-tmp, rename)."""
     fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
@@ -292,15 +263,14 @@ def _atomic_write_parquet(path: Path, df: pd.DataFrame, schema_meta: dict) -> No
     import pyarrow.parquet as pq
 
     table = pa.Table.from_pandas(df, preserve_index=False)
-    # Merge custom schema version metadata into existing Parquet metadata.
     existing_meta = table.schema.metadata or {}
     merged_meta = {
         **existing_meta,
         b"terraflow_schema_version": FEATURES_SCHEMA_VERSION.encode(),
         **{
-            k.encode() if isinstance(k, str) else k: v.encode()
-            if isinstance(v, str)
-            else v
+            k.encode() if isinstance(k, str) else k: (
+                v.encode() if isinstance(v, str) else v
+            )
             for k, v in schema_meta.items()
         },
     }
@@ -319,11 +289,6 @@ def _atomic_write_parquet(path: Path, df: pd.DataFrame, schema_meta: dict) -> No
         raise
 
 
-# ---------------------------------------------------------------------------
-# Git SHA helper (optional; gracefully omitted when unavailable)
-# ---------------------------------------------------------------------------
-
-
 def _get_git_sha() -> Optional[str]:
     """Return the current HEAD SHA, or ``None`` if not in a git repo."""
     try:
@@ -340,9 +305,201 @@ def _get_git_sha() -> Optional[str]:
     return None
 
 
-# ---------------------------------------------------------------------------
-# Main pipeline entry point
-# ---------------------------------------------------------------------------
+def _project_cells_to_wgs84(
+    sampled_indices: List[tuple[int, int]],
+    clipped_transform: rasterio.Affine,
+    raster_crs: CRS,
+) -> tuple[List[float], List[float]]:
+    """Return (cell_lats, cell_lons) in WGS84 for the sampled cell grid positions."""
+    native_xs: List[float] = []
+    native_ys: List[float] = []
+    for row, col in sampled_indices:
+        x, y = xy(clipped_transform, row, col, offset="center")
+        native_xs.append(float(x))
+        native_ys.append(float(y))
+
+    wgs84 = CRS.from_epsg(4326)
+    if raster_crs != wgs84:
+        coord_tf = Transformer.from_crs(raster_crs, wgs84, always_xy=True)
+        lons, lats = coord_tf.transform(native_xs, native_ys)
+        return list(lats), list(lons)
+    return native_ys, native_xs  # native_xs=lon, native_ys=lat
+
+
+def _score_cells(
+    clipped_data: np.ma.MaskedArray,
+    sampled_indices: List[tuple[int, int]],
+    cell_lats: List[float],
+    cell_lons: List[float],
+    cell_climate_df: pd.DataFrame,
+    cfg: PipelineConfig,
+    run_fingerprint: str,
+) -> tuple[pd.DataFrame, List[str]]:
+    """Score each sampled cell and return (features DataFrame, kriging std col names)."""
+    krig_std_cols = [c for c in cell_climate_df.columns if c.endswith("_krig_std")]
+    records: List[Dict[str, Any]] = []
+
+    for cell_id, (row, col) in enumerate(sampled_indices):
+        v_index = float(clipped_data[row, col])
+        mean_temp = float(cell_climate_df.iloc[cell_id]["mean_temp"])
+        total_rain = float(cell_climate_df.iloc[cell_id]["total_rain"])
+        score = suitability_score(
+            v_index=v_index,
+            mean_temp=mean_temp,
+            total_rain=total_rain,
+            params=cfg.model_params,
+        )
+        record: Dict[str, Any] = {
+            "run_id": run_fingerprint,
+            "cell_id": cell_id,
+            "lat": cell_lats[cell_id],
+            "lon": cell_lons[cell_id],
+            "v_index": v_index,
+            "mean_temp": mean_temp,
+            "total_rain": total_rain,
+            "score": score,
+            "label": suitability_label(score),
+        }
+        for ksc in krig_std_cols:
+            record[ksc] = float(cell_climate_df.iloc[cell_id][ksc])
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records)
+    return df, krig_std_cols
+
+
+def _apply_monte_carlo(
+    df: pd.DataFrame,
+    krig_std_cols: List[str],
+    cfg: PipelineConfig,
+    rng: np.random.Generator,
+) -> tuple[pd.DataFrame, List[str]]:
+    """Add Monte Carlo CI columns to *df* if configured; returns updated df and new col names.
+
+    Requires uncertainty_samples > 0 and kriging std columns present.
+    Perturbs mean_temp and total_rain using per-cell kriging std, then scores
+    each draw to derive 5th/95th percentile confidence intervals on the
+    suitability score.
+    """
+    n_mc = cfg.model_params.uncertainty_samples
+    if n_mc <= 0 or not krig_std_cols:
+        if n_mc > 0:
+            logger.warning(
+                f"uncertainty_samples={n_mc} but no kriging std columns available; "
+                "skipping Monte Carlo. Set interpolation_method='kriging' to enable."
+            )
+        return df, []
+
+    n_cells = len(df)
+    v_arr = df["v_index"].to_numpy()
+    temp_arr = df["mean_temp"].to_numpy()
+    rain_arr = df["total_rain"].to_numpy()
+    # Clip std to ≥ 0 (kriging variance is non-negative but may have
+    # tiny floating-point negatives at station locations).
+    temp_std = np.maximum(df["mean_temp_krig_std"].to_numpy(), 0.0)
+    rain_std = np.maximum(df["total_rain_krig_std"].to_numpy(), 0.0)
+
+    # Shape: (n_cells, n_mc) — rng continues deterministic stream.
+    temp_mc = rng.normal(temp_arr[:, None], temp_std[:, None], (n_cells, n_mc))
+    rain_mc = rng.normal(rain_arr[:, None], rain_std[:, None], (n_cells, n_mc))
+    # v_index has no per-cell uncertainty estimate; broadcast constant.
+    v_mc = np.broadcast_to(v_arr[:, None], (n_cells, n_mc))
+
+    scores_mc = suitability_score_array(v_mc, temp_mc, rain_mc, cfg.model_params)
+    df["score_ci_low"] = np.percentile(scores_mc, 5, axis=1)
+    df["score_ci_high"] = np.percentile(scores_mc, 95, axis=1)
+    logger.info(
+        f"Monte Carlo uncertainty propagation complete: {n_mc} samples per cell"
+    )
+    return df, ["score_ci_low", "score_ci_high"]
+
+
+def _build_report(
+    run_fingerprint: str,
+    clipped_data: np.ma.MaskedArray,
+    climate_df: pd.DataFrame,
+    df: pd.DataFrame,
+    n_cells_sampled: int,
+    n_total_cells: int,
+    n_valid_cells: int,
+    n_nodata_cells: int,
+    interpolator: "ClimateInterpolator",
+    mc_ci_cols: List[str],
+    n_mc: int,
+    timings: Dict[str, float],
+) -> Dict[str, Any]:
+    """Build the report.json payload."""
+    raster_vals = clipped_data.compressed().astype("float64")
+    climate_var_cols = [c for c in climate_df.columns if c not in ("lat", "lon")]
+    climate_var_stats: Dict[str, Any] = {
+        var: {
+            "mean": float(col.mean()) if len(col := climate_df[var].dropna()) else None,
+            "min": float(col.min()) if len(col) else None,
+            "max": float(col.max()) if len(col) else None,
+            "n_nodata": int(climate_df[var].isna().sum()),
+        }
+        for var in climate_var_cols
+    }
+    scores_arr = df["score"].to_numpy()
+
+    report: Dict[str, Any] = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "run_fingerprint": run_fingerprint,
+        "coverage": {
+            "n_raster_cells_total": n_total_cells,
+            "n_roi_valid_cells": n_valid_cells,
+            "n_roi_nodata_cells": n_nodata_cells,
+            "roi_coverage_fraction": (
+                round(n_valid_cells / n_total_cells, 6) if n_total_cells else 0.0
+            ),
+            "roi_nodata_fraction": (
+                round(n_nodata_cells / n_total_cells, 6) if n_total_cells else 0.0
+            ),
+        },
+        "raster_stats": {
+            "count": int(raster_vals.size),
+            "mean": float(raster_vals.mean()) if raster_vals.size else None,
+            "std": float(raster_vals.std(ddof=1)) if raster_vals.size > 1 else 0.0,
+            "min": float(raster_vals.min()) if raster_vals.size else None,
+            "max": float(raster_vals.max()) if raster_vals.size else None,
+        },
+        "climate_stats": {"n_rows": len(climate_df), "variables": climate_var_stats},
+        "n_cells_sampled": n_cells_sampled,
+        "score_stats": {
+            "mean": float(scores_arr.mean()) if len(scores_arr) else None,
+            "std": float(scores_arr.std(ddof=1)) if len(scores_arr) > 1 else 0.0,
+            "min": float(scores_arr.min()) if len(scores_arr) else None,
+            "max": float(scores_arr.max()) if len(scores_arr) else None,
+        },
+        "timings_sec": timings,
+    }
+
+    if interpolator.cv_metrics:
+        report["kriging_loocv"] = {
+            var: round(stats["rmse"], 6)
+            for var, stats in interpolator.cv_metrics.get("per_variable", {}).items()
+            if stats.get("rmse") is not None
+        }
+        report["interpolation_cv"] = interpolator.cv_metrics
+
+    if interpolator.variogram_params:
+        report["kriging_diagnostics"] = interpolator.variogram_params
+
+    if mc_ci_cols:
+        ci_low = df["score_ci_low"].to_numpy()
+        ci_high = df["score_ci_high"].to_numpy()
+        report["uncertainty"] = {
+            "method": "monte_carlo",
+            "n_samples": n_mc,
+            "perturbed_variables": ["mean_temp", "total_rain"],
+            "ci_low_pct": 5,
+            "ci_high_pct": 95,
+            "score_ci_low_mean": float(ci_low.mean()),
+            "score_ci_high_mean": float(ci_high.mean()),
+            "mean_ci_width": float((ci_high - ci_low).mean()),
+        }
+
+    return report
 
 
 def run_pipeline(config_path: str | Path) -> pd.DataFrame:
@@ -386,7 +543,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     config_dict = load_config_dict(config_path)
     config_dir = config_path.resolve().parent
 
-    # Resolve relative input/output paths against the config file's directory.
     for _key in ("raster_path", "climate_csv", "output_dir"):
         if _key in config_dict and config_dict[_key] is not None:
             _p = Path(str(config_dict[_key]))
@@ -395,7 +551,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
 
     cfg: PipelineConfig = build_config(config_dict)
     logger.info(f"Loaded config from {config_path}")
-
     config_bytes_hash = hashlib.sha256(canonicalize_config(config_dict)).hexdigest()
     roi_hash = _resolve_roi_hash(config_dict, config_dir)
     input_paths = _collect_input_paths(config_dict, config_dir)
@@ -414,7 +569,9 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         run_dir / "report.json",
     ]
     if all(p.exists() for p in _required_artifacts):
-        logger.info(f"Detected identical run {run_fingerprint} — all artifacts present, returning cached result.")
+        logger.info(
+            f"Detected identical run {run_fingerprint} — all artifacts present, returning cached result."
+        )
         df = pd.read_parquet(run_dir / "features.parquet")
         df.attrs["run_fingerprint"] = run_fingerprint
         df.attrs["run_dir"] = str(run_dir)
@@ -434,7 +591,11 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         raise
     _t_load = time.perf_counter() - _t_load_start
 
-    _crs_str = f"EPSG:{raster_crs.to_epsg()}" if raster_crs is not None and raster_crs.to_epsg() else (str(raster_crs) if raster_crs else "None")
+    _crs_str = (
+        f"EPSG:{raster_crs.to_epsg()}"
+        if raster_crs is not None and raster_crs.to_epsg()
+        else (str(raster_crs) if raster_crs else "None")
+    )
     logger.info(f"Loaded raster: {cfg.raster_path} (CRS: {_crs_str})")
     logger.info(f"Loaded climate data: {cfg.climate_csv}")
 
@@ -462,11 +623,8 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     _t_clip = time.perf_counter() - _t_clip_start
     logger.info("Clipped raster to ROI")
 
-    rows: int
-    cols: int
     rows, cols = clipped_data.shape
     n_total_cells = rows * cols
-
     valid_indices: List[tuple[int, int]] = [
         (r, c)
         for r in range(rows)
@@ -483,6 +641,7 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         climate_df=climate_df,
         strategy=cfg.climate.strategy,
         interpolation_method=cfg.climate.interpolation_method,
+        variogram_mode=cfg.climate.variogram_mode,
         cell_id_column=cfg.climate.cell_id_column,
         fallback_to_mean=cfg.climate.fallback_to_mean,
     )
@@ -502,114 +661,29 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
     sampled_indices = [valid_indices[i] for i in _sample_idx]
     logger.info(f"Sampled {max_cells} cells from {n_valid_cells} valid cells in ROI")
 
-    # Pre-compute cell centre coordinates in native raster CRS.
-    _native_xs: List[float] = []
-    _native_ys: List[float] = []
-    for row, col in sampled_indices:
-        x, y = xy(clipped_transform, row, col, offset="center")
-        _native_xs.append(float(x))
-        _native_ys.append(float(y))
-
-    # Reproject to WGS84 (EPSG:4326).
-    _wgs84 = CRS.from_epsg(4326)
-    if raster_crs != _wgs84:
-        _coord_tf = Transformer.from_crs(raster_crs, _wgs84, always_xy=True)
-        _lons, _lats = _coord_tf.transform(_native_xs, _native_ys)
-        cell_lons: List[float] = list(_lons)
-        cell_lats: List[float] = list(_lats)
-    else:
-        cell_lons = _native_xs
-        cell_lats = _native_ys
+    cell_lats, cell_lons = _project_cells_to_wgs84(
+        sampled_indices, clipped_transform, raster_crs
+    )
 
     _t_interp_start = time.perf_counter()
     cell_climate_df = interpolator.interpolate(np.array(cell_lats), np.array(cell_lons))
     _t_interp = time.perf_counter() - _t_interp_start
-    logger.info(f"Interpolated climate for {len(sampled_indices)} cells using strategy='{cfg.climate.strategy}'")
+    logger.info(
+        f"Interpolated climate for {len(sampled_indices)} cells using strategy='{cfg.climate.strategy}'"
+    )
 
     _t_score_start = time.perf_counter()
-    records: List[Dict[str, Any]] = []
-
-    # Detect kriging std columns (present when interpolation_method="kriging").
-    _krig_std_cols = [c for c in cell_climate_df.columns if c.endswith("_krig_std")]
-
-    for cell_id, (row, col) in enumerate(sampled_indices):
-        v_index = float(clipped_data[row, col])
-        lat = cell_lats[cell_id]
-        lon = cell_lons[cell_id]
-        mean_temp = float(cell_climate_df.iloc[cell_id]["mean_temp"])
-        total_rain = float(cell_climate_df.iloc[cell_id]["total_rain"])
-
-        score = suitability_score(
-            v_index=v_index,
-            mean_temp=mean_temp,
-            total_rain=total_rain,
-            params=cfg.model_params,
-        )
-        label = suitability_label(score)
-
-        record: Dict[str, Any] = {
-            "run_id": run_fingerprint,
-            "cell_id": cell_id,
-            "lat": lat,
-            "lon": lon,
-            "v_index": v_index,
-            "mean_temp": mean_temp,
-            "total_rain": total_rain,
-            "score": score,
-            "label": label,
-        }
-        # Append per-cell kriging std columns when kriging was used.
-        for ksc in _krig_std_cols:
-            record[ksc] = float(cell_climate_df.iloc[cell_id][ksc])
-
-        records.append(record)
-
-    df = pd.DataFrame.from_records(records)
-
-    # --- Monte Carlo uncertainty propagation ---------------------------------
-    # Requires: uncertainty_samples > 0 AND kriging std columns present.
-    # Perturbs mean_temp and total_rain independently using their per-cell
-    # kriging standard deviations, then scores each draw to derive 5th/95th
-    # percentile confidence intervals on the suitability score.
-    _mc_ci_cols: List[str] = []
-    _n_mc = cfg.model_params.uncertainty_samples
-    if _n_mc > 0:
-        if _krig_std_cols:
-            _mc_ci_cols = ["score_ci_low", "score_ci_high"]
-            _n_cells = len(df)
-            _v_arr = df["v_index"].to_numpy()
-            _temp_arr = df["mean_temp"].to_numpy()
-            _rain_arr = df["total_rain"].to_numpy()
-            # Clip std to ≥ 0 (kriging variance is non-negative but may have
-            # tiny floating-point negatives at station locations).
-            _temp_std = np.maximum(df["mean_temp_krig_std"].to_numpy(), 0.0)
-            _rain_std = np.maximum(df["total_rain_krig_std"].to_numpy(), 0.0)
-
-            # Shape: (n_cells, n_mc) — rng continues deterministic stream.
-            _temp_mc = rng.normal(
-                _temp_arr[:, None], _temp_std[:, None], (_n_cells, _n_mc)
-            )
-            _rain_mc = rng.normal(
-                _rain_arr[:, None], _rain_std[:, None], (_n_cells, _n_mc)
-            )
-            # v_index has no per-cell uncertainty estimate; broadcast constant.
-            _v_mc = np.broadcast_to(_v_arr[:, None], (_n_cells, _n_mc))
-
-            _scores_mc = suitability_score_array(
-                _v_mc, _temp_mc, _rain_mc, cfg.model_params
-            )  # (n_cells, n_mc), values in [0, 1]
-
-            df["score_ci_low"] = np.percentile(_scores_mc, 5, axis=1)
-            df["score_ci_high"] = np.percentile(_scores_mc, 95, axis=1)
-            logger.info(f"Monte Carlo uncertainty propagation complete: {_n_mc} samples per cell")
-        else:
-            logger.warning(
-                f"uncertainty_samples={_n_mc} but no kriging std columns available; "
-                "skipping Monte Carlo. Set interpolation_method='kriging' to enable."
-            )
-
-    # Enforce stable base column order, then append kriging std and CI columns.
-    df = df[FEATURES_COLUMNS_ORDERED + _krig_std_cols + _mc_ci_cols]
+    df, krig_std_cols = _score_cells(
+        clipped_data,
+        sampled_indices,
+        cell_lats,
+        cell_lons,
+        cell_climate_df,
+        cfg,
+        run_fingerprint,
+    )
+    df, mc_ci_cols = _apply_monte_carlo(df, krig_std_cols, cfg, rng)
+    df = df[FEATURES_COLUMNS_ORDERED + krig_std_cols + mc_ci_cols]
     _t_score = time.perf_counter() - _t_score_start
 
     raster.close()
@@ -622,7 +696,6 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         df,
         schema_meta={"run_fingerprint": run_fingerprint},
     )
-
     _atomic_write_text(run_dir / "results.csv", df.to_csv(index=False))
 
     git_sha = _get_git_sha()
@@ -653,114 +726,46 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         ],
     }
     _atomic_write_text(
-        run_dir / "manifest.json",
-        json.dumps(manifest, indent=2, default=str),
+        run_dir / "manifest.json", json.dumps(manifest, indent=2, default=str)
     )
 
-    raster_data_for_report = clipped_data.compressed().astype("float64")
-    climate_var_cols = [c for c in climate_df.columns if c not in ("lat", "lon")]
-    climate_var_stats: Dict[str, Any] = {}
-    for var in climate_var_cols:
-        col = climate_df[var].dropna()
-        climate_var_stats[var] = {
-            "mean": float(col.mean()) if len(col) else None,
-            "min": float(col.min()) if len(col) else None,
-            "max": float(col.max()) if len(col) else None,
-            "n_nodata": int(climate_df[var].isna().sum()),
-        }
-
-    scores_arr = df["score"].to_numpy()
     _t_total = time.perf_counter() - _t_total_start
     _t_write = time.perf_counter() - _t_write_start
 
-    report: Dict[str, Any] = {
-        "schema_version": REPORT_SCHEMA_VERSION,
-        "run_fingerprint": run_fingerprint,
-        "coverage": {
-            "n_raster_cells_total": n_total_cells,
-            "n_roi_valid_cells": n_valid_cells,
-            "n_roi_nodata_cells": n_nodata_cells,
-            "roi_coverage_fraction": (
-                round(n_valid_cells / n_total_cells, 6) if n_total_cells else 0.0
-            ),
-            "roi_nodata_fraction": (
-                round(n_nodata_cells / n_total_cells, 6) if n_total_cells else 0.0
-            ),
-        },
-        "raster_stats": {
-            "count": int(raster_data_for_report.size),
-            "mean": float(raster_data_for_report.mean()) if raster_data_for_report.size else None,
-            "std": float(raster_data_for_report.std(ddof=1)) if raster_data_for_report.size > 1 else 0.0,
-            "min": float(raster_data_for_report.min()) if raster_data_for_report.size else None,
-            "max": float(raster_data_for_report.max()) if raster_data_for_report.size else None,
-        },
-        "climate_stats": {
-            "n_rows": len(climate_df),
-            "variables": climate_var_stats,
-        },
-        "n_cells_sampled": len(records),
-        "score_stats": {
-            "mean": float(scores_arr.mean()) if len(scores_arr) else None,
-            "std": float(scores_arr.std(ddof=1)) if len(scores_arr) > 1 else 0.0,
-            "min": float(scores_arr.min()) if len(scores_arr) else None,
-            "max": float(scores_arr.max()) if len(scores_arr) else None,
-        },
-        "timings_sec": {
-            "build_catalog": round(_t_catalog, 4),
-            "load_inputs": round(_t_load, 4),
-            "clip_roi": round(_t_clip, 4),
-            "interpolate_climate": round(_t_interp, 4),
-            "score_cells": round(_t_score, 4),
-            "write_outputs": round(_t_write, 4),
-            "total": round(_t_total, 4),
-        },
+    timings = {
+        "build_catalog": round(_t_catalog, 4),
+        "load_inputs": round(_t_load, 4),
+        "clip_roi": round(_t_clip, 4),
+        "interpolate_climate": round(_t_interp, 4),
+        "score_cells": round(_t_score, 4),
+        "write_outputs": round(_t_write, 4),
+        "total": round(_t_total, 4),
     }
-    # Include LOOCV cross-validation metrics when kriging was used.
-    if interpolator.cv_metrics:
-        # VALD-03: expose per-variable LOOCV RMSE under 'kriging_loocv'
-        report["kriging_loocv"] = {
-            var: round(stats["rmse"], 6)
-            for var, stats in interpolator.cv_metrics.get("per_variable", {}).items()
-            if stats.get("rmse") is not None
-        }
-        report["interpolation_cv"] = interpolator.cv_metrics  # retain for compat
-
-    # Include variogram diagnostics when kriging was used.
-    if interpolator.variogram_params:
-        report["kriging_diagnostics"] = interpolator.variogram_params
-
-    # Include Monte Carlo uncertainty summary when CI columns were produced.
-    if _mc_ci_cols:
-        _ci_low = df["score_ci_low"].to_numpy()
-        _ci_high = df["score_ci_high"].to_numpy()
-        report["uncertainty"] = {
-            "method": "monte_carlo",
-            "n_samples": _n_mc,
-            "perturbed_variables": ["mean_temp", "total_rain"],
-            "ci_low_pct": 5,
-            "ci_high_pct": 95,
-            "score_ci_low_mean": float(_ci_low.mean()),
-            "score_ci_high_mean": float(_ci_high.mean()),
-            "mean_ci_width": float((_ci_high - _ci_low).mean()),
-        }
-
+    report = _build_report(
+        run_fingerprint,
+        clipped_data,
+        climate_df,
+        df,
+        n_cells_sampled=len(df),
+        n_total_cells=n_total_cells,
+        n_valid_cells=n_valid_cells,
+        n_nodata_cells=n_nodata_cells,
+        interpolator=interpolator,
+        mc_ci_cols=mc_ci_cols,
+        n_mc=cfg.model_params.uncertainty_samples,
+        timings=timings,
+    )
     _atomic_write_text(
-        run_dir / "report.json",
-        json.dumps(report, indent=2, default=str),
+        run_dir / "report.json", json.dumps(report, indent=2, default=str)
     )
 
     logger.info(
-        f"Artifacts written to {run_dir} (fingerprint={run_fingerprint}, cells={len(records)}, total={_t_total:.2f}s)"
+        f"Artifacts written to {run_dir} (fingerprint={run_fingerprint}, cells={len(df)}, total={_t_total:.2f}s)"
     )
 
     df.attrs["run_fingerprint"] = run_fingerprint
     df.attrs["run_dir"] = str(run_dir)
     return df
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _get_package_version() -> str:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -643,7 +643,25 @@ class TestKrigingInterpolation:
             strategy="spatial",
             interpolation_method="kriging",
         )
-        assert interpolator._krig_variogram_model in ("spherical", "exponential", "gaussian")
+        assert interpolator._krig_variogram_model in (
+            "spherical",
+            "exponential",
+            "gaussian",
+        )
+
+    def test_kriging_extended_variogram_mode_reports_candidate_scores(self):
+        interpolator = ClimateInterpolator(
+            climate_df=_dense_climate_df(),
+            strategy="spatial",
+            interpolation_method="kriging",
+            variogram_mode="extended",
+        )
+        assert interpolator.cv_metrics["variogram_mode"] == "extended"
+        candidate_scores = interpolator.cv_metrics["candidate_scores"]
+        assert "spherical" in candidate_scores
+        assert "nested_spherical_gaussian" in candidate_scores
+        assert "nested_exponential_gaussian" in candidate_scores
+        assert interpolator._krig_variogram_model in candidate_scores
 
     def test_kriging_fallback_to_linear_too_few_stations(self):
         """Kriging must fall back to linear when stations < MIN_KRIGING_STATIONS."""
@@ -842,12 +860,77 @@ class TestPipelineKrigingIntegration:
         cfg_file.write_text(cfg_content, encoding="utf-8")
 
         df = run_pipeline(cfg_file)
-        report = json.loads((tmp_path / "outputs" / "runs" / df.attrs["run_fingerprint"] / "report.json").read_text())
+        report = json.loads(
+            (
+                tmp_path
+                / "outputs"
+                / "runs"
+                / df.attrs["run_fingerprint"]
+                / "report.json"
+            ).read_text()
+        )
 
         assert "interpolation_cv" in report
         cv = report["interpolation_cv"]
         assert "variogram_model" in cv
         assert "per_variable" in cv
+
+    def test_pipeline_kriging_extended_mode_reports_candidate_scores(
+        self, tmp_path, synthetic_raster, synthetic_climate_csv_dense
+    ):
+        import json
+        import textwrap
+
+        from terraflow.pipeline import run_pipeline
+
+        cfg_content = textwrap.dedent(f"""
+            raster_path: "{synthetic_raster}"
+            climate_csv: "{synthetic_climate_csv_dense}"
+            output_dir: "{tmp_path / 'outputs'}"
+
+            roi:
+              type: "bbox"
+              xmin: -100.04
+              ymin: 39.96
+              xmax: -99.96
+              ymax: 40.01
+
+            climate:
+              strategy: "spatial"
+              interpolation_method: "kriging"
+              variogram_mode: "extended"
+
+            model_params:
+              v_min: 0.0
+              v_max: 25.0
+              t_min: 0.0
+              t_max: 40.0
+              r_min: 0.0
+              r_max: 300.0
+              w_v: 0.4
+              w_t: 0.3
+              w_r: 0.3
+
+            max_cells: 5
+        """)
+        cfg_file = tmp_path / "cfg_kriging_extended.yml"
+        cfg_file.write_text(cfg_content, encoding="utf-8")
+
+        df = run_pipeline(cfg_file)
+        report = json.loads(
+            (
+                tmp_path
+                / "outputs"
+                / "runs"
+                / df.attrs["run_fingerprint"]
+                / "report.json"
+            ).read_text()
+        )
+
+        cv = report["interpolation_cv"]
+        assert cv["variogram_mode"] == "extended"
+        assert "candidate_scores" in cv
+        assert "nested_spherical_gaussian" in cv["candidate_scores"]
 
 
 # ---------------------------------------------------------------------------
@@ -857,14 +940,16 @@ class TestPipelineKrigingIntegration:
 
 def test_kriging_fallback_sparse_stations():
     """With < MIN_KRIGING_STATIONS stations, kriging falls back to linear."""
-    from terraflow.climate import ClimateInterpolator, MIN_KRIGING_STATIONS
+    from terraflow.climate import MIN_KRIGING_STATIONS, ClimateInterpolator
 
-    sparse_df = pd.DataFrame({
-        "lat": [40.0, 40.01],
-        "lon": [-100.0, -99.99],
-        "mean_temp": [18.0, 20.0],
-        "total_rain": [100.0, 120.0],
-    })
+    sparse_df = pd.DataFrame(
+        {
+            "lat": [40.0, 40.01],
+            "lon": [-100.0, -99.99],
+            "mean_temp": [18.0, 20.0],
+            "total_rain": [100.0, 120.0],
+        }
+    )
     assert len(sparse_df) < MIN_KRIGING_STATIONS
 
     interpolator = ClimateInterpolator(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,3 +139,36 @@ def test_load_config_invalid_max_cells(tmp_path: Path):
 
     with pytest.raises(ValueError, match="max_cells"):
         load_config(cfg_file)
+
+
+def test_load_config_kriging_variogram_mode(tmp_path: Path):
+    cfg_content = textwrap.dedent("""
+        raster_path: "data/usda_cdl.tif"
+        climate_csv: "data/demo_climate.csv"
+        output_dir: "outputs/demo_run"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 10.0
+          ymax: 10.0
+        climate:
+          strategy: "spatial"
+          interpolation_method: "kriging"
+          variogram_mode: "extended"
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        """)
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(cfg_content, encoding="utf-8")
+
+    cfg = load_config(cfg_file)
+    assert cfg.climate.variogram_mode == "extended"

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -203,3 +203,48 @@ def test_clip_preserves_masked_values(tmp_path: Path):
         data, _ = clip_raster_to_roi(src, roi)
         # The masked array should properly handle NoData
         assert data is not None
+
+
+def test_clip_raster_to_roi_reads_tight_window_for_small_roi(tmp_path: Path, monkeypatch):
+    raster_path = tmp_path / "large_raster.tif"
+    arr = np.arange(10_000, dtype="float32").reshape(100, 100)
+    transform = from_origin(west=0.0, north=100.0, xsize=1.0, ysize=1.0)
+
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype=arr.dtype,
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(arr, 1)
+
+    with rasterio.open(raster_path) as src:
+        original_read = src.read
+        seen = {}
+
+        def tracking_read(*args, **kwargs):
+            seen["window"] = kwargs.get("window")
+            return original_read(*args, **kwargs)
+
+        monkeypatch.setattr(src, "read", tracking_read)
+        data, _ = clip_raster_to_roi(
+            src,
+            {
+                "xmin": 10.2,
+                "ymin": 89.2,
+                "xmax": 10.8,
+                "ymax": 89.8,
+            },
+        )
+
+    window = seen["window"]
+    assert window is not None
+    assert data.shape == (1, 1)
+    assert window.width == 1
+    assert window.height == 1
+    assert window.width * window.height < 100


### PR DESCRIPTION
## Summary
- add `variogram_mode` support for kriging and evaluate nested extended variogram candidates with LOOCV reporting
- tighten ROI clipping to pixel-snapped intersecting windows and add a regression test for sub-1% ROI reads
- document the new kriging configuration and extend coverage in config, geo, climate, and pipeline tests

## Why
Issue #35 asks for an extended kriging candidate set with reportable LOOCV diagnostics.
Issue #36 asks for tighter windowed raster reads and explicit coverage for very small ROIs.

## Validation
- `pytest tests/test_config.py tests/test_geo.py tests/test_climate.py -q`

Closes #35
Closes #36