### PR TITLE
[codex] address issues #35 and #36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 - `climate.variogram_mode` config for kriging. The default `standard` mode keeps the existing spherical/exponential/Gaussian candidate set; `extended` mode also evaluates nested variogram candidates and records LOOCV candidate scores in `report.json`.
+- Notebook `05_extended_variogram_mode.ipynb` demonstrating extended kriging variogram selection with synthetic station data.
 
 ### Changed
 - Removed decorative section-banner comments and self-evident inline comments throughout `pipeline.py`, `ingest.py`, `geo.py`, and `climate.py`; comments now appear only at genuinely complex logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- `climate.variogram_mode` config for kriging. The default `standard` mode keeps the existing spherical/exponential/Gaussian candidate set; `extended` mode also evaluates nested variogram candidates and records LOOCV candidate scores in `report.json`.
+
 ### Changed
 - Removed decorative section-banner comments and self-evident inline comments throughout `pipeline.py`, `ingest.py`, `geo.py`, and `climate.py`; comments now appear only at genuinely complex logic.
 - Refactored `run_pipeline()` into four extracted helpers (`_project_cells_to_wgs84`, `_score_cells`, `_apply_monte_carlo`, `_build_report`) reducing the function from 425 lines to ~130 lines of orchestration and cutting cognitive complexity below SonarQube thresholds.
 - Moved `import math` inline call in `geo.py` to module-level import.
 
 ### Fixed
+- ROI clipping now snaps requested bounds to an intersecting pixel window so very small ROIs avoid oversized raster reads.
 - Closed resolved issues: H3-01 (#60), H3-02 (#61), H3-03 (#62), H3-04 (#63), and #40 (all implemented in prior phases).
 
 ## [0.2.2] — 2026-04-12

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Three spatial algorithms are available via `interpolation_method`:
 | `idw` | Inverse Distance Weighting (power=2) — faster than kriging, no uncertainty |
 
 Combine `interpolation_method: kriging` with `uncertainty_samples: N` in `model_params` to get Monte Carlo score confidence intervals (`score_ci_low` / `score_ci_high`).
-For kriging, `variogram_mode: extended` evaluates additional nested variogram candidates and records all LOOCV candidate scores in `report.json`; use the default `standard` mode for large station networks unless nested structures are needed.
+For kriging, `variogram_mode: extended` evaluates additional nested variogram candidates and records all LOOCV candidate scores in `report.json`; use the default `standard` mode for large station networks unless nested structures are needed. See the extended variogram notebook in the docs for a worked synthetic example.
 
 See [Config Schema](https://terraflow.marupilla.dev/config/schema/) for the full reference.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Three spatial algorithms are available via `interpolation_method`:
 | `idw` | Inverse Distance Weighting (power=2) — faster than kriging, no uncertainty |
 
 Combine `interpolation_method: kriging` with `uncertainty_samples: N` in `model_params` to get Monte Carlo score confidence intervals (`score_ci_low` / `score_ci_high`).
+For kriging, `variogram_mode: extended` evaluates additional nested variogram candidates and records all LOOCV candidate scores in `report.json`; use the default `standard` mode for large station networks unless nested structures are needed.
 
 See [Config Schema](https://terraflow.marupilla.dev/config/schema/) for the full reference.
 

--- a/docs/config/examples.md
+++ b/docs/config/examples.md
@@ -66,9 +66,12 @@ model_params:
 climate:
   strategy: spatial
   interpolation_method: kriging
+  variogram_mode: standard
   fallback_to_mean: true
 max_cells: 250
 ```
+
+Set `variogram_mode: extended` when you want TerraFlow to try additional nested variogram candidates before selecting the best kriging model.
 
 ## IDW (fast, no uncertainty)
 

--- a/docs/config/examples.md
+++ b/docs/config/examples.md
@@ -71,7 +71,7 @@ climate:
 max_cells: 250
 ```
 
-Set `variogram_mode: extended` when you want TerraFlow to try additional nested variogram candidates before selecting the best kriging model.
+Set `variogram_mode: extended` when you want TerraFlow to try additional nested variogram candidates before selecting the best kriging model. Extended mode is more expensive than standard kriging because each nested candidate fits a custom variogram before LOOCV; prefer standard mode for large station networks unless nested structures are specifically needed.
 
 ## IDW (fast, no uncertainty)
 

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -116,6 +116,7 @@ Climate data is applied ==per-cell== using configurable interpolation strategies
 |---|---|---|---|
 | `strategy` | string | `"spatial"` | `"spatial"` or `"index"` — how cells are matched to climate observations |
 | `interpolation_method` | string | `"linear"` | `"linear"`, `"kriging"`, or `"idw"` — spatial algorithm (ignored when `strategy: index`) |
+| `variogram_mode` | string | `"standard"` | `"standard"` tries spherical/exponential/Gaussian; `"extended"` also evaluates nested kriging candidates (kriging only) |
 | `fallback_to_mean` | bool | `true` | Use global mean for cells outside interpolation range |
 | `cell_id_column` | string | `null` | Column for explicit cell ID matching (index strategy only) |
 
@@ -141,11 +142,14 @@ Climate data is applied ==per-cell== using configurable interpolation strategies
     climate:
       strategy: spatial
       interpolation_method: kriging
+      variogram_mode: standard
       fallback_to_mean: true
     model_params:
       # ... other params ...
       uncertainty_samples: 500  # produces score_ci_low / score_ci_high
     ```
+
+    Set `variogram_mode: extended` to evaluate additional nested candidates and record their LOOCV scores in `report.json`.
 
     !!! note "Requires pykrige"
         Install with `pip install terraflow-agro[kriging]` or `pip install pykrige`.
@@ -187,4 +191,4 @@ lat,lon,mean_temp,total_rain
 - **`lon`**: Longitude in [-180, 180]
 - **Climate variables**: One or more numeric columns (`mean_temp`, `total_rain`, etc.)
 
-If `climate` is omitted entirely, defaults to `strategy: spatial`, `interpolation_method: linear`, `fallback_to_mean: true`.
+If `climate` is omitted entirely, defaults to `strategy: spatial`, `interpolation_method: linear`, `variogram_mode: standard`, `fallback_to_mean: true`.

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -149,7 +149,7 @@ Climate data is applied ==per-cell== using configurable interpolation strategies
       uncertainty_samples: 500  # produces score_ci_low / score_ci_high
     ```
 
-    Set `variogram_mode: extended` to evaluate additional nested candidates and record their LOOCV scores in `report.json`.
+    Set `variogram_mode: extended` to evaluate additional nested candidates and record their LOOCV scores in `report.json`. Extended mode fits custom nested variograms before LOOCV, so it is slower than standard mode on large station networks.
 
     !!! note "Requires pykrige"
         Install with `pip install terraflow-agro[kriging]` or `pip install pykrige`.

--- a/docs/notebooks/05_extended_variogram_mode.ipynb
+++ b/docs/notebooks/05_extended_variogram_mode.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extended Variogram Mode\n",
+    "\n",
+    "This notebook shows how to enable TerraFlow's extended kriging variogram search on a small synthetic station network. Extended mode evaluates the default spherical, exponential, and Gaussian candidates plus nested variogram candidates, then records candidate LOOCV scores in `interpolation_cv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from terraflow.climate import ClimateInterpolator\n",
+    "\n",
+    "climate_df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"lat\": [39.97, 39.97, 39.97, 39.97, 40.00, 40.00, 40.00, 40.00],\n",
+    "        \"lon\": [-100.03, -100.01, -99.99, -99.97, -100.03, -100.01, -99.99, -99.97],\n",
+    "        \"mean_temp\": [17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0],\n",
+    "        \"total_rain\": [90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "interpolator = ClimateInterpolator(\n",
+    "    climate_df=climate_df,\n",
+    "    strategy=\"spatial\",\n",
+    "    interpolation_method=\"kriging\",\n",
+    "    variogram_mode=\"extended\",\n",
+    ")\n",
+    "\n",
+    "interpolator.cv_metrics[\"candidate_scores\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the default `variogram_mode: standard` for large station networks unless nested structures are specifically needed. Extended mode fits custom nested variograms before LOOCV, so it is intentionally more expensive than standard kriging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cell_lats = np.array([39.985, 39.995])\n",
+    "cell_lons = np.array([-100.005, -99.985])\n",
+    "\n",
+    "interpolator.interpolate(cell_lats, cell_lons)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
   - Notebooks:
       - TerraFlow v0.2.0 Demo: notebooks/terraflow_v0_2_0_comprehensive_test.ipynb
       - Kriging and Uncertainty: notebooks/kriging_uncertainty_demo.ipynb
+      - Extended Variogram Mode: notebooks/05_extended_variogram_mode.ipynb
       - Sensitivity Analysis: notebooks/02_sensitivity_analysis.ipynb
       - Model Validation: notebooks/03_model_validation.ipynb
       - H3 Export: notebooks/04_h3_export.ipynb

--- a/terraflow/climate.py
+++ b/terraflow/climate.py
@@ -44,7 +44,7 @@ Example
 from __future__ import annotations
 
 import logging
-from typing import Dict, Literal, Optional, Tuple
+from typing import Callable, Dict, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -61,6 +61,49 @@ MIN_KRIGING_STATIONS: int = 5
 
 #: Variogram models tried during automatic model selection.
 _VARIOGRAM_MODELS: Tuple[str, ...] = ("spherical", "exponential", "gaussian")
+
+
+def _nested_spherical_gaussian_variogram(m: np.ndarray, d: np.ndarray) -> np.ndarray:
+    psill_sph, range_sph, psill_gau, range_gau, nugget = m
+    d = np.asarray(d, dtype=float)
+    gamma = np.full_like(d, float(nugget), dtype=float)
+
+    safe_range_sph = max(float(range_sph), 1e-12)
+    h = d / safe_range_sph
+    spherical = np.where(
+        d <= safe_range_sph,
+        float(psill_sph) * (1.5 * h - 0.5 * h**3),
+        float(psill_sph),
+    )
+
+    safe_range_gau = max(float(range_gau), 1e-12)
+    gaussian = float(psill_gau) * (
+        1.0 - np.exp(-(d**2) / ((safe_range_gau * 4.0 / 7.0) ** 2))
+    )
+    return gamma + spherical + gaussian
+
+
+def _nested_exponential_gaussian_variogram(
+    m: np.ndarray, d: np.ndarray
+) -> np.ndarray:
+    psill_exp, range_exp, psill_gau, range_gau, nugget = m
+    d = np.asarray(d, dtype=float)
+
+    safe_range_exp = max(float(range_exp), 1e-12)
+    safe_range_gau = max(float(range_gau), 1e-12)
+    exponential = float(psill_exp) * (
+        1.0 - np.exp(-d / (safe_range_exp / 3.0))
+    )
+    gaussian = float(psill_gau) * (
+        1.0 - np.exp(-(d**2) / ((safe_range_gau * 4.0 / 7.0) ** 2))
+    )
+    return float(nugget) + exponential + gaussian
+
+
+_NESTED_VARIOGRAM_FUNCTIONS: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = {
+    "nested_spherical_gaussian": _nested_spherical_gaussian_variogram,
+    "nested_exponential_gaussian": _nested_exponential_gaussian_variogram,
+}
 
 
 class CoordinateRange(BaseModel):
@@ -141,6 +184,7 @@ class ClimateInterpolator:
         climate_df: pd.DataFrame,
         strategy: Literal["spatial", "index"] = "spatial",
         interpolation_method: Literal["linear", "kriging", "idw"] = "linear",
+        variogram_mode: Literal["standard", "extended"] = "standard",
         cell_id_column: Optional[str] = None,
         fallback_to_mean: bool = True,
     ):
@@ -179,15 +223,28 @@ class ClimateInterpolator:
                 f"interpolation_method must be 'linear', 'kriging', or 'idw', "
                 f"got '{interpolation_method}'"
             )
+        if variogram_mode not in ("standard", "extended"):
+            raise ValueError(
+                f"variogram_mode must be 'standard' or 'extended', got '{variogram_mode}'"
+            )
+        if interpolation_method != "kriging" and variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when interpolation_method='kriging'"
+            )
 
         self.climate_df = climate_df.copy()
         self.strategy = strategy
         self.interpolation_method = interpolation_method
+        self.variogram_mode = variogram_mode
         self.cell_id_column = cell_id_column
         self.fallback_to_mean = fallback_to_mean
         self.cv_metrics: Dict = {}
         self._krig_variogram_model: str = "spherical"  # overwritten by _init_kriging
         self.variogram_params: dict = {}
+        self._krig_variogram_parameters: Optional[Tuple[float, ...]] = None
+        self._krig_variogram_function: Optional[
+            Callable[[np.ndarray, np.ndarray], np.ndarray]
+        ] = None
 
         self._validate_columns()
 
@@ -201,8 +258,137 @@ class ClimateInterpolator:
 
         logger.info(
             f"ClimateInterpolator initialised: strategy='{strategy}', "
-            f"interpolation_method='{interpolation_method}', records={len(self.climate_df)}, variables={self.climate_columns}"
+            f"interpolation_method='{interpolation_method}', variogram_mode='{variogram_mode}', "
+            f"records={len(self.climate_df)}, variables={self.climate_columns}"
         )
+
+    def _candidate_model_names(self) -> Tuple[str, ...]:
+        if self.variogram_mode == "extended":
+            return _VARIOGRAM_MODELS + tuple(_NESTED_VARIOGRAM_FUNCTIONS.keys())
+        return _VARIOGRAM_MODELS
+
+    def _build_ok(
+        self,
+        lons: np.ndarray,
+        lats: np.ndarray,
+        vals: np.ndarray,
+        model_name: str,
+        variogram_parameters: Optional[Tuple[float, ...]] = None,
+    ):
+        from pykrige.ok import OrdinaryKriging
+
+        kwargs = {
+            "verbose": False,
+            "enable_plotting": False,
+        }
+        if model_name in _NESTED_VARIOGRAM_FUNCTIONS:
+            kwargs.update(
+                {
+                    "variogram_model": "custom",
+                    "variogram_parameters": (
+                        list(variogram_parameters)
+                        if variogram_parameters is not None
+                        else None
+                    ),
+                    "variogram_function": _NESTED_VARIOGRAM_FUNCTIONS[model_name],
+                }
+            )
+        else:
+            kwargs["variogram_model"] = model_name
+            if variogram_parameters is not None:
+                kwargs["variogram_parameters"] = variogram_parameters
+        return OrdinaryKriging(lons, lats, vals, **kwargs)
+
+    def _fit_nested_variogram(
+        self,
+        lons: np.ndarray,
+        lats: np.ndarray,
+        vals: np.ndarray,
+        model_name: str,
+        initial_parameters: Optional[Tuple[float, ...]] = None,
+    ) -> Tuple[float, ...]:
+        from scipy.optimize import curve_fit
+
+        probe = self._build_ok(lons, lats, vals, "spherical")
+        lags = np.asarray(probe.lags, dtype=float)
+        semivariance = np.asarray(probe.semivariance, dtype=float)
+        if lags.size == 0 or semivariance.size == 0:
+            raise ValueError("No empirical semivariogram points available")
+
+        max_lag = float(max(np.nanmax(lags), 1e-6))
+        sill_guess = float(max(np.nanmax(semivariance), 1e-6))
+        nugget_guess = float(max(np.nanmin(semivariance), 0.0))
+        psill_total = max(sill_guess - nugget_guess, 1e-6)
+        initial = (
+            np.asarray(initial_parameters, dtype=float)
+            if initial_parameters is not None
+            else np.array(
+                [
+                    psill_total * 0.6,
+                    max_lag / 3.0,
+                    psill_total * 0.4,
+                    max_lag * 0.75,
+                    nugget_guess,
+                ],
+                dtype=float,
+            )
+        )
+        lower = np.array([1e-9, 1e-9, 1e-9, 1e-9, 0.0], dtype=float)
+        upper = np.array(
+            [sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0],
+            dtype=float,
+        )
+
+        variogram_fn = _NESTED_VARIOGRAM_FUNCTIONS[model_name]
+        params, _ = curve_fit(
+            lambda dist, *m: variogram_fn(np.asarray(m, dtype=float), dist),
+            lags,
+            semivariance,
+            p0=initial,
+            bounds=(lower, upper),
+            maxfev=20000,
+        )
+        return tuple(float(p) for p in params)
+
+    def _build_variogram_diagnostics(
+        self, model_name: str, parameters: Tuple[float, ...]
+    ) -> Dict:
+        rounded = [round(float(x), 6) for x in parameters]
+        diagnostics: Dict = {
+            "model": model_name,
+            "mode": self.variogram_mode,
+            "parameters": rounded,
+            "range_units": "degrees_geographic",
+        }
+        if model_name in _NESTED_VARIOGRAM_FUNCTIONS and len(parameters) >= 5:
+            diagnostics.update(
+                {
+                    "psill": round(float(parameters[0]), 6),
+                    "nugget": round(float(parameters[4]), 6),
+                    "sill": round(float(parameters[0]) + float(parameters[4]), 6),
+                    "range_": round(float(parameters[1]), 6),
+                    "nested_components": [
+                        {
+                            "psill": round(float(parameters[0]), 6),
+                            "range_": round(float(parameters[1]), 6),
+                        },
+                        {
+                            "psill": round(float(parameters[2]), 6),
+                            "range_": round(float(parameters[3]), 6),
+                        },
+                    ],
+                }
+            )
+        elif len(parameters) >= 3:
+            diagnostics.update(
+                {
+                    "psill": round(float(parameters[0]), 6),
+                    "nugget": round(float(parameters[2]), 6),
+                    "sill": round(float(parameters[0]) + float(parameters[2]), 6),
+                    "range_": round(float(parameters[1]), 6),
+                }
+            )
+        return diagnostics
 
     def _validate_columns(self) -> None:
         """Validate that climate data has required columns."""
@@ -307,17 +493,31 @@ class ClimateInterpolator:
         vals_primary = self.climate_df[primary_var].values.astype(float)
 
         best_model: Optional[str] = None
+        best_model_params: Optional[Tuple[float, ...]] = None
         best_rmse = np.inf
+        candidate_scores: Dict[str, Dict[str, float]] = {}
 
-        for model in _VARIOGRAM_MODELS:
+        for model in self._candidate_model_names():
             try:
-                rmse, _ = self._loocv(lons, lats, vals_primary, model)
+                model_params = None
+                if model in _NESTED_VARIOGRAM_FUNCTIONS:
+                    model_params = self._fit_nested_variogram(
+                        lons, lats, vals_primary, model
+                    )
+                rmse, mae = self._loocv(
+                    lons, lats, vals_primary, model, model_params
+                )
+                candidate_scores[model] = {
+                    "rmse": round(float(rmse), 6),
+                    "mae": round(float(mae), 6),
+                }
                 logger.debug(
                     f"Variogram '{model}': LOOCV RMSE={rmse:.4f} ({primary_var})"
                 )
                 if rmse < best_rmse:
                     best_rmse = rmse
                     best_model = model
+                    best_model_params = model_params
             except (ValueError, RuntimeError, np.linalg.LinAlgError) as exc:
                 logger.debug(
                     f"Variogram model '{model}' failed during selection: {exc}"
@@ -331,35 +531,25 @@ class ClimateInterpolator:
             return
 
         self._krig_variogram_model = best_model
+        self._krig_variogram_parameters = best_model_params
+        self._krig_variogram_function = _NESTED_VARIOGRAM_FUNCTIONS.get(best_model)
         logger.info(
             f"Kriging variogram selected: '{best_model}' (LOOCV RMSE={best_rmse:.4f} for '{primary_var}')"
         )
 
-        from pykrige.ok import OrdinaryKriging
-
-        _ok_full = OrdinaryKriging(
-            lons,
-            lats,
-            vals_primary,
-            variogram_model=best_model,
-            verbose=False,
-            enable_plotting=False,
+        _ok_full = self._build_ok(
+            lons, lats, vals_primary, best_model, best_model_params
         )
-        p = _ok_full.variogram_model_parameters  # [psill, range, nugget]
-        self.variogram_params = {
-            "model": best_model,
-            "psill": round(float(p[0]), 6),
-            "nugget": round(float(p[2]), 6),
-            "sill": round(float(p[0]) + float(p[2]), 6),
-            "range_": round(float(p[1]), 6),
-            "range_units": "degrees_geographic",
-        }
+        p = tuple(float(x) for x in _ok_full.variogram_model_parameters)
+        self.variogram_params = self._build_variogram_diagnostics(best_model, p)
 
         cv_per_var: Dict = {}
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
             try:
-                rmse, mae = self._loocv(lons, lats, vals, best_model)
+                rmse, mae = self._loocv(
+                    lons, lats, vals, best_model, best_model_params
+                )
                 cv_per_var[var] = {
                     "rmse": round(float(rmse), 6),
                     "mae": round(float(mae), 6),
@@ -372,24 +562,30 @@ class ClimateInterpolator:
         self.cv_metrics = {
             "method": "loocv",
             "variogram_model": best_model,
+            "variogram_mode": self.variogram_mode,
+            "candidate_scores": candidate_scores,
             "per_variable": cv_per_var,
         }
 
     def _loocv(
-        self, lons: np.ndarray, lats: np.ndarray, vals: np.ndarray, model: str
+        self,
+        lons: np.ndarray,
+        lats: np.ndarray,
+        vals: np.ndarray,
+        model: str,
+        variogram_parameters: Optional[Tuple[float, ...]] = None,
     ) -> Tuple[float, float]:
         """Return (RMSE, MAE) via Leave-One-Out Cross-Validation for a variogram model."""
-        from pykrige.ok import OrdinaryKriging
+        if model in _NESTED_VARIOGRAM_FUNCTIONS and variogram_parameters is None:
+            variogram_parameters = self._fit_nested_variogram(lons, lats, vals, model)
 
         errors = []
         for i in range(len(vals)):
-            ok = OrdinaryKriging(
-                np.delete(lons, i),
-                np.delete(lats, i),
-                np.delete(vals, i),
-                variogram_model=model,
-                verbose=False,
-                enable_plotting=False,
+            train_lons = np.delete(lons, i)
+            train_lats = np.delete(lats, i)
+            train_vals = np.delete(vals, i)
+            ok = self._build_ok(
+                train_lons, train_lats, train_vals, model, variogram_parameters
             )
             pred, _ = ok.execute("points", np.array([lons[i]]), np.array([lats[i]]))
             errors.append(float(pred[0]) - vals[i])
@@ -510,13 +706,12 @@ class ClimateInterpolator:
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
 
-            ok = OrdinaryKriging(
+            ok = self._build_ok(
                 lons_src,
                 lats_src,
                 vals,
-                variogram_model=self._krig_variogram_model,
-                verbose=False,
-                enable_plotting=False,
+                self._krig_variogram_model,
+                self._krig_variogram_parameters,
             )
             z_pred, sigma_sq = ok.execute("points", cell_lons_arr, cell_lats_arr)
 

--- a/terraflow/climate.py
+++ b/terraflow/climate.py
@@ -223,10 +223,6 @@ class ClimateInterpolator:
                 f"interpolation_method must be 'linear', 'kriging', or 'idw', "
                 f"got '{interpolation_method}'"
             )
-        if variogram_mode not in ("standard", "extended"):
-            raise ValueError(
-                f"variogram_mode must be 'standard' or 'extended', got '{variogram_mode}'"
-            )
         if interpolation_method != "kriging" and variogram_mode != "standard":
             raise ValueError(
                 "variogram_mode only applies when interpolation_method='kriging'"

--- a/terraflow/climate.py
+++ b/terraflow/climate.py
@@ -44,7 +44,7 @@ Example
 from __future__ import annotations
 
 import logging
-from typing import Callable, Dict, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -83,24 +83,22 @@ def _nested_spherical_gaussian_variogram(m: np.ndarray, d: np.ndarray) -> np.nda
     return gamma + spherical + gaussian
 
 
-def _nested_exponential_gaussian_variogram(
-    m: np.ndarray, d: np.ndarray
-) -> np.ndarray:
+def _nested_exponential_gaussian_variogram(m: np.ndarray, d: np.ndarray) -> np.ndarray:
     psill_exp, range_exp, psill_gau, range_gau, nugget = m
     d = np.asarray(d, dtype=float)
 
     safe_range_exp = max(float(range_exp), 1e-12)
     safe_range_gau = max(float(range_gau), 1e-12)
-    exponential = float(psill_exp) * (
-        1.0 - np.exp(-d / (safe_range_exp / 3.0))
-    )
+    exponential = float(psill_exp) * (1.0 - np.exp(-d / (safe_range_exp / 3.0)))
     gaussian = float(psill_gau) * (
         1.0 - np.exp(-(d**2) / ((safe_range_gau * 4.0 / 7.0) ** 2))
     )
     return float(nugget) + exponential + gaussian
 
 
-_NESTED_VARIOGRAM_FUNCTIONS: Dict[str, Callable[[np.ndarray, np.ndarray], np.ndarray]] = {
+_NESTED_VARIOGRAM_FUNCTIONS: Dict[
+    str, Callable[[np.ndarray, np.ndarray], np.ndarray]
+] = {
     "nested_spherical_gaussian": _nested_spherical_gaussian_variogram,
     "nested_exponential_gaussian": _nested_exponential_gaussian_variogram,
 }
@@ -273,7 +271,7 @@ class ClimateInterpolator:
     ):
         from pykrige.ok import OrdinaryKriging
 
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "verbose": False,
             "enable_plotting": False,
         }
@@ -331,7 +329,13 @@ class ClimateInterpolator:
         )
         lower = np.array([1e-9, 1e-9, 1e-9, 1e-9, 0.0], dtype=float)
         upper = np.array(
-            [sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0, max_lag * 10.0, sill_guess * 10.0],
+            [
+                sill_guess * 10.0,
+                max_lag * 10.0,
+                sill_guess * 10.0,
+                max_lag * 10.0,
+                sill_guess * 10.0,
+            ],
             dtype=float,
         )
 
@@ -500,9 +504,7 @@ class ClimateInterpolator:
                     model_params = self._fit_nested_variogram(
                         lons, lats, vals_primary, model
                     )
-                rmse, mae = self._loocv(
-                    lons, lats, vals_primary, model, model_params
-                )
+                rmse, mae = self._loocv(lons, lats, vals_primary, model, model_params)
                 candidate_scores[model] = {
                     "rmse": round(float(rmse), 6),
                     "mae": round(float(mae), 6),
@@ -543,9 +545,7 @@ class ClimateInterpolator:
         for var in self.climate_columns:
             vals = self.climate_df[var].values.astype(float)
             try:
-                rmse, mae = self._loocv(
-                    lons, lats, vals, best_model, best_model_params
-                )
+                rmse, mae = self._loocv(lons, lats, vals, best_model, best_model_params)
                 cv_per_var[var] = {
                     "rmse": round(float(rmse), 6),
                     "mae": round(float(mae), 6),
@@ -691,7 +691,6 @@ class ClimateInterpolator:
         one ``{var}_krig_std`` column per climate variable (kriging prediction
         standard deviation = sqrt of kriging variance).
         """
-        from pykrige.ok import OrdinaryKriging
 
         lons_src = self.climate_df["lon"].values.astype(float)
         lats_src = self.climate_df["lat"].values.astype(float)

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -181,16 +181,6 @@ class ClimateConfig(BaseModel):
             )
         return v
 
-    @field_validator("variogram_mode")
-    @classmethod
-    def validate_variogram_mode(cls, v: str) -> str:
-        """Ensure variogram_mode is valid."""
-        if v not in ("standard", "extended"):
-            raise ValueError(
-                f"variogram_mode must be 'standard' or 'extended', got '{v}'"
-            )
-        return v
-
     def validate_config(self) -> None:
         """Validate consistency of climate configuration."""
         if self.strategy != "spatial" and self.variogram_mode != "standard":

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -157,6 +157,7 @@ class ClimateConfig(BaseModel):
 
     strategy: Literal["spatial", "index"] = "spatial"
     interpolation_method: Literal["linear", "kriging", "idw"] = "linear"
+    variogram_mode: Literal["standard", "extended"] = "standard"
     cell_id_column: str | None = None
     fallback_to_mean: bool = True
 
@@ -180,10 +181,26 @@ class ClimateConfig(BaseModel):
             )
         return v
 
+    @field_validator("variogram_mode")
+    @classmethod
+    def validate_variogram_mode(cls, v: str) -> str:
+        """Ensure variogram_mode is valid."""
+        if v not in ("standard", "extended"):
+            raise ValueError(
+                f"variogram_mode must be 'standard' or 'extended', got '{v}'"
+            )
+        return v
+
     def validate_config(self) -> None:
         """Validate consistency of climate configuration."""
-        # interpolation_method only applies to spatial strategy
-        pass
+        if self.strategy != "spatial" and self.variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when climate.strategy='spatial'"
+            )
+        if self.interpolation_method != "kriging" and self.variogram_mode != "standard":
+            raise ValueError(
+                "variogram_mode only applies when interpolation_method='kriging'"
+            )
 
 
 class WeightBounds(BaseModel):

--- a/terraflow/geo.py
+++ b/terraflow/geo.py
@@ -5,6 +5,7 @@ import numpy as np
 import rasterio
 from pyproj import Transformer
 from rasterio.crs import CRS
+from rasterio.errors import WindowError
 from rasterio.io import DatasetReader
 from rasterio.windows import Window, from_bounds
 
@@ -91,6 +92,18 @@ def clip_raster_to_roi(
             f"Check that roi_crs='{roi_crs}' is correct and that the ROI "
             f"coordinates are valid in that CRS."
         )
+
+    # Snap to pixel boundaries and clamp to the raster extent so small ROIs
+    # read only the intersecting window instead of an oversized float window.
+    full_window = Window(col_off=0, row_off=0, width=raster.width, height=raster.height)
+    try:
+        window = window.round_offsets().round_lengths().intersection(full_window)
+    except WindowError as e:
+        raise ValueError(
+            f"ROI does not intersect the raster (raster extent: {raster.bounds}). "
+            f"Verify that roi_crs='{roi_crs}' matches the coordinate system of "
+            f"your xmin/ymin/xmax/ymax values."
+        ) from e
 
     data = raster.read(1, window=window, masked=True)
     transform = raster.window_transform(window)

--- a/terraflow/geo.py
+++ b/terraflow/geo.py
@@ -73,8 +73,27 @@ def clip_raster_to_roi(
             f"xmin={xmin:.2f} ymin={ymin:.2f} xmax={xmax:.2f} ymax={ymax:.2f}"
         )
 
+    raster_bounds = raster.bounds
+    clipped_xmin = max(xmin, raster_bounds.left)
+    clipped_ymin = max(ymin, raster_bounds.bottom)
+    clipped_xmax = min(xmax, raster_bounds.right)
+    clipped_ymax = min(ymax, raster_bounds.top)
+
+    if clipped_xmin >= clipped_xmax or clipped_ymin >= clipped_ymax:
+        raise ValueError(
+            f"ROI does not intersect the raster (raster extent: {raster.bounds}). "
+            f"Verify that roi_crs='{roi_crs}' matches the coordinate system of "
+            f"your xmin/ymin/xmax/ymax values."
+        )
+
     try:
-        window: Window = from_bounds(xmin, ymin, xmax, ymax, transform=raster.transform)
+        window: Window = from_bounds(
+            clipped_xmin,
+            clipped_ymin,
+            clipped_xmax,
+            clipped_ymax,
+            transform=raster.transform,
+        )
     except Exception as e:
         raise ValueError(
             f"Could not compute raster window for ROI bounds "

--- a/terraflow/pipeline.py
+++ b/terraflow/pipeline.py
@@ -641,6 +641,7 @@ def run_pipeline(config_path: str | Path) -> pd.DataFrame:
         climate_df=climate_df,
         strategy=cfg.climate.strategy,
         interpolation_method=cfg.climate.interpolation_method,
+        variogram_mode=cfg.climate.variogram_mode,
         cell_id_column=cfg.climate.cell_id_column,
         fallback_to_mean=cfg.climate.fallback_to_mean,
     )

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -56,7 +56,8 @@ def _make_config(
     ymax: float = 41.0,
     max_cells: int = 5,
 ) -> Path:
-    content = textwrap.dedent(f"""
+    content = textwrap.dedent(
+        f"""
         raster_path: "{raster_path}"
         climate_csv: "{climate_csv}"
         output_dir: "{tmp_path / 'outputs'}"
@@ -77,7 +78,8 @@ def _make_config(
           w_t: 0.3
           w_r: 0.3
         max_cells: {max_cells}
-    """)
+    """
+    )
     cfg = tmp_path / "config.yml"
     cfg.write_text(content, encoding="utf-8")
     return cfg
@@ -443,7 +445,8 @@ class TestCrsMismatch:
         climate_path.write_text("lat,lon,mean_temp,total_rain\n38.5,-99.0,20.0,120.0\n")
 
         # ROI is valid bbox but far away from the raster (Africa vs North America)
-        cfg_content = textwrap.dedent(f"""
+        cfg_content = textwrap.dedent(
+            f"""
             raster_path: "{raster_path}"
             climate_csv: "{climate_path}"
             output_dir: "{tmp_path / 'out'}"
@@ -465,7 +468,8 @@ class TestCrsMismatch:
               w_t: 0.3
               w_r: 0.3
             max_cells: 5
-        """)
+        """
+        )
         cfg_file = tmp_path / "cfg.yml"
         cfg_file.write_text(cfg_content)
 
@@ -524,7 +528,8 @@ class TestNodataCoverage:
             "39.99,-99.99,19.0,110.0\n"
         )
 
-        cfg_content = textwrap.dedent(f"""
+        cfg_content = textwrap.dedent(
+            f"""
             raster_path: "{raster_path}"
             climate_csv: "{climate_path}"
             output_dir: "{tmp_path / 'out'}"
@@ -545,7 +550,8 @@ class TestNodataCoverage:
               w_t: 0.3
               w_r: 0.3
             max_cells: 10
-        """)
+        """
+        )
         cfg_file = tmp_path / "cfg.yml"
         cfg_file.write_text(cfg_content)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,7 +121,8 @@ max_cells: 10
 
 def test_cli_raster_file_not_found(tmp_path: Path, capsys):
     """Test CLI error handling when raster file doesn't exist."""
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "nonexistent_raster.tif"
         climate_csv: "data/climate.csv"
         output_dir: "outputs"
@@ -142,7 +143,8 @@ def test_cli_raster_file_not_found(tmp_path: Path, capsys):
           w_t: 0.3
           w_r: 0.3
         max_cells: 10
-        """)
+        """
+    )
 
     cfg_file = tmp_path / "test_config.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
@@ -162,7 +164,8 @@ def test_cli_climate_file_not_found(tmp_path: Path, capsys):
     import rasterio
     from rasterio.transform import from_origin
 
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/synthetic_raster.tif"
         climate_csv: "nonexistent_climate.csv"
         output_dir: "outputs"
@@ -183,7 +186,8 @@ def test_cli_climate_file_not_found(tmp_path: Path, capsys):
           w_t: 0.3
           w_r: 0.3
         max_cells: 10
-        """)
+        """
+    )
 
     cfg_file = tmp_path / "test_config.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -649,6 +649,34 @@ class TestKrigingInterpolation:
             "gaussian",
         )
 
+    def test_kriging_extended_variogram_mode_reports_candidate_scores(self):
+        interpolator = ClimateInterpolator(
+            climate_df=_dense_climate_df(),
+            strategy="spatial",
+            interpolation_method="kriging",
+            variogram_mode="extended",
+        )
+        assert interpolator.cv_metrics["variogram_mode"] == "extended"
+        candidate_scores = interpolator.cv_metrics["candidate_scores"]
+        assert "spherical" in candidate_scores
+        assert "nested_spherical_gaussian" in candidate_scores
+        assert "nested_exponential_gaussian" in candidate_scores
+        assert interpolator._krig_variogram_model in candidate_scores
+
+    def test_kriging_extended_diagnostics_keep_legacy_keys(self):
+        interpolator = ClimateInterpolator(
+            climate_df=_dense_climate_df(),
+            strategy="spatial",
+            interpolation_method="kriging",
+            variogram_mode="extended",
+        )
+        diagnostics = interpolator.variogram_params
+        for key in ("model", "psill", "nugget", "sill", "range_", "range_units"):
+            assert key in diagnostics
+        assert diagnostics["sill"] == pytest.approx(
+            diagnostics["psill"] + diagnostics["nugget"], rel=1e-4
+        )
+
     def test_kriging_fallback_to_linear_too_few_stations(self):
         """Kriging must fall back to linear when stations < MIN_KRIGING_STATIONS."""
         sparse_df = pd.DataFrame(
@@ -860,6 +888,63 @@ class TestPipelineKrigingIntegration:
         cv = report["interpolation_cv"]
         assert "variogram_model" in cv
         assert "per_variable" in cv
+
+    def test_pipeline_kriging_extended_mode_reports_candidate_scores(
+        self, tmp_path, synthetic_raster, synthetic_climate_csv_dense
+    ):
+        import json
+        import textwrap
+
+        from terraflow.pipeline import run_pipeline
+
+        cfg_content = textwrap.dedent(f"""
+            raster_path: "{synthetic_raster}"
+            climate_csv: "{synthetic_climate_csv_dense}"
+            output_dir: "{tmp_path / 'outputs'}"
+
+            roi:
+              type: "bbox"
+              xmin: -100.04
+              ymin: 39.96
+              xmax: -99.96
+              ymax: 40.01
+
+            climate:
+              strategy: "spatial"
+              interpolation_method: "kriging"
+              variogram_mode: "extended"
+
+            model_params:
+              v_min: 0.0
+              v_max: 25.0
+              t_min: 0.0
+              t_max: 40.0
+              r_min: 0.0
+              r_max: 300.0
+              w_v: 0.4
+              w_t: 0.3
+              w_r: 0.3
+
+            max_cells: 5
+        """)
+        cfg_file = tmp_path / "cfg_kriging_extended.yml"
+        cfg_file.write_text(cfg_content, encoding="utf-8")
+
+        df = run_pipeline(cfg_file)
+        report = json.loads(
+            (
+                tmp_path
+                / "outputs"
+                / "runs"
+                / df.attrs["run_fingerprint"]
+                / "report.json"
+            ).read_text()
+        )
+
+        cv = report["interpolation_cv"]
+        assert cv["variogram_mode"] == "extended"
+        assert "candidate_scores" in cv
+        assert "nested_spherical_gaussian" in cv["candidate_scores"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -793,7 +793,8 @@ class TestPipelineKrigingIntegration:
 
         from terraflow.pipeline import run_pipeline
 
-        cfg_content = textwrap.dedent(f"""
+        cfg_content = textwrap.dedent(
+            f"""
             raster_path: "{synthetic_raster}"
             climate_csv: "{synthetic_climate_csv_dense}"
             output_dir: "{tmp_path / 'outputs'}"
@@ -821,7 +822,8 @@ class TestPipelineKrigingIntegration:
               w_r: 0.3
 
             max_cells: 5
-        """)
+        """
+        )
         cfg_file = tmp_path / "cfg_kriging.yml"
         cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -841,7 +843,8 @@ class TestPipelineKrigingIntegration:
 
         from terraflow.pipeline import run_pipeline
 
-        cfg_content = textwrap.dedent(f"""
+        cfg_content = textwrap.dedent(
+            f"""
             raster_path: "{synthetic_raster}"
             climate_csv: "{synthetic_climate_csv_dense}"
             output_dir: "{tmp_path / 'outputs'}"
@@ -869,7 +872,8 @@ class TestPipelineKrigingIntegration:
               w_r: 0.3
 
             max_cells: 5
-        """)
+        """
+        )
         cfg_file = tmp_path / "cfg_kriging2.yml"
         cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -897,7 +901,8 @@ class TestPipelineKrigingIntegration:
 
         from terraflow.pipeline import run_pipeline
 
-        cfg_content = textwrap.dedent(f"""
+        cfg_content = textwrap.dedent(
+            f"""
             raster_path: "{synthetic_raster}"
             climate_csv: "{synthetic_climate_csv_dense}"
             output_dir: "{tmp_path / 'outputs'}"
@@ -926,7 +931,8 @@ class TestPipelineKrigingIntegration:
               w_r: 0.3
 
             max_cells: 5
-        """)
+        """
+        )
         cfg_file = tmp_path / "cfg_kriging_extended.yml"
         cfg_file.write_text(cfg_content, encoding="utf-8")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,8 @@ from terraflow.config import load_config
 
 
 def test_load_config_tmp(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -27,7 +28,8 @@ def test_load_config_tmp(tmp_path: Path):
           w_v: 0.4
           w_t: 0.3
           w_r: 0.3
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -54,7 +56,8 @@ def test_load_config_invalid_yaml(tmp_path: Path):
 
 
 def test_load_config_invalid_weights(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -74,7 +77,8 @@ def test_load_config_invalid_weights(tmp_path: Path):
           w_v: 0.5
           w_t: 0.5
           w_r: 0.5
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -83,7 +87,8 @@ def test_load_config_invalid_weights(tmp_path: Path):
 
 
 def test_load_config_invalid_roi_bounds(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -103,7 +108,8 @@ def test_load_config_invalid_roi_bounds(tmp_path: Path):
           w_v: 0.4
           w_t: 0.3
           w_r: 0.3
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -112,7 +118,8 @@ def test_load_config_invalid_roi_bounds(tmp_path: Path):
 
 
 def test_load_config_invalid_max_cells(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -133,7 +140,8 @@ def test_load_config_invalid_max_cells(tmp_path: Path):
           w_t: 0.3
           w_r: 0.3
         max_cells: -5
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 
@@ -142,7 +150,8 @@ def test_load_config_invalid_max_cells(tmp_path: Path):
 
 
 def test_load_config_kriging_variogram_mode(tmp_path: Path):
-    cfg_content = textwrap.dedent("""
+    cfg_content = textwrap.dedent(
+        """
         raster_path: "data/usda_cdl.tif"
         climate_csv: "data/demo_climate.csv"
         output_dir: "outputs/demo_run"
@@ -166,7 +175,8 @@ def test_load_config_kriging_variogram_mode(tmp_path: Path):
           w_v: 0.4
           w_t: 0.3
           w_r: 0.3
-        """)
+        """
+    )
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,3 +139,36 @@ def test_load_config_invalid_max_cells(tmp_path: Path):
 
     with pytest.raises(ValueError, match="max_cells"):
         load_config(cfg_file)
+
+
+def test_load_config_kriging_variogram_mode(tmp_path: Path):
+    cfg_content = textwrap.dedent("""
+        raster_path: "data/usda_cdl.tif"
+        climate_csv: "data/demo_climate.csv"
+        output_dir: "outputs/demo_run"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 10.0
+          ymax: 10.0
+        climate:
+          strategy: "spatial"
+          interpolation_method: "kriging"
+          variogram_mode: "extended"
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        """)
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(cfg_content, encoding="utf-8")
+
+    cfg = load_config(cfg_file)
+    assert cfg.climate.variogram_mode == "extended"

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -14,7 +14,8 @@ import pandas as pd
 
 
 def _write_config(cfg_file: Path, raster: Path, climate: Path, out_dir: Path) -> Path:
-    cfg = textwrap.dedent(f"""
+    cfg = textwrap.dedent(
+        f"""
         raster_path: "{raster}"
         climate_csv: "{climate}"
         output_dir: "{out_dir}"
@@ -38,7 +39,8 @@ def _write_config(cfg_file: Path, raster: Path, climate: Path, out_dir: Path) ->
           w_r: 0.3
 
         max_cells: 3
-    """)
+    """
+    )
     cfg_file.write_text(cfg, encoding="utf-8")
     return cfg_file
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -203,3 +203,48 @@ def test_clip_preserves_masked_values(tmp_path: Path):
         data, _ = clip_raster_to_roi(src, roi)
         # The masked array should properly handle NoData
         assert data is not None
+
+
+def test_clip_raster_to_roi_reads_tight_window_for_small_roi(tmp_path: Path, monkeypatch):
+    raster_path = tmp_path / "large_raster.tif"
+    arr = np.arange(10_000, dtype="float32").reshape(100, 100)
+    transform = from_origin(west=0.0, north=100.0, xsize=1.0, ysize=1.0)
+
+    with rasterio.open(
+        raster_path,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype=arr.dtype,
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(arr, 1)
+
+    with rasterio.open(raster_path) as src:
+        original_read = src.read
+        seen = {}
+
+        def tracking_read(*args, **kwargs):
+            seen["window"] = kwargs.get("window")
+            return original_read(*args, **kwargs)
+
+        monkeypatch.setattr(src, "read", tracking_read)
+        data, _ = clip_raster_to_roi(
+            src,
+            {
+                "xmin": 10.2,
+                "ymin": 89.2,
+                "xmax": 10.8,
+                "ymax": 89.8,
+            },
+        )
+
+    window = seen["window"]
+    assert window is not None
+    assert data.shape == (1, 1)
+    assert window.width == 1
+    assert window.height == 1
+    assert window.width * window.height < 100

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -73,6 +73,26 @@ def test_clip_raster_roi_outside_bounds_raises(tmp_path: Path):
             )
 
 
+def test_clip_raster_to_roi_partial_overlap_reads_intersection(tmp_path: Path):
+    """ROI partially outside raster extent should still read intersecting pixels."""
+    raster_path = _make_small_raster(tmp_path)
+    with rasterio.open(raster_path) as src:
+        data, transform = clip_raster_to_roi(
+            src,
+            {
+                "xmin": -100.005,
+                "ymin": 39.995,
+                "xmax": -99.985,
+                "ymax": 40.015,
+            },
+        )
+
+    assert data.size > 0
+    assert data.shape[0] >= 1
+    assert data.shape[1] >= 1
+    assert transform is not None
+
+
 def _make_projected_raster(tmp_path: Path) -> tuple[Path, dict]:
     """Create a synthetic UTM Zone 14N (EPSG:32614) raster over Kansas.
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -225,7 +225,9 @@ def test_clip_preserves_masked_values(tmp_path: Path):
         assert data is not None
 
 
-def test_clip_raster_to_roi_reads_tight_window_for_small_roi(tmp_path: Path, monkeypatch):
+def test_clip_raster_to_roi_reads_tight_window_for_small_roi(
+    tmp_path: Path, monkeypatch
+):
     raster_path = tmp_path / "large_raster.tif"
     arr = np.arange(10_000, dtype="float32").reshape(100, 100)
     transform = from_origin(west=0.0, north=100.0, xsize=1.0, ysize=1.0)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,8 @@ def test_run_pipeline_with_synthetic_data(
 ):
     out_dir = tmp_path / "outputs"
 
-    cfg_content = textwrap.dedent(f"""
+    cfg_content = textwrap.dedent(
+        f"""
         raster_path: "{synthetic_raster}"
         climate_csv: "{synthetic_climate_csv}"
         output_dir: "{out_dir}"
@@ -43,7 +44,8 @@ def test_run_pipeline_with_synthetic_data(
           w_r: 0.3
 
         max_cells: 10
-        """)
+        """
+    )
 
     cfg_file = tmp_path / "cfg.yml"
     cfg_file.write_text(cfg_content, encoding="utf-8")
@@ -250,7 +252,8 @@ def _write_kriging_config(
     uncertainty_samples: int = 0,
 ) -> Path:
     """Write a pipeline config YAML file with kriging interpolation enabled."""
-    cfg = textwrap.dedent(f"""
+    cfg = textwrap.dedent(
+        f"""
         raster_path: "{raster_path}"
         climate_csv: "{climate_csv}"
         output_dir: "{output_dir}"
@@ -279,7 +282,8 @@ def _write_kriging_config(
           interpolation_method: "kriging"
 
         max_cells: 5
-    """)
+    """
+    )
     cfg_file.write_text(cfg, encoding="utf-8")
     return cfg_file
 
@@ -359,7 +363,9 @@ def test_resolve_run_dir_returns_deterministic_path(
 
     cfg_path = tmp_path / "cfg.yml"
     out_dir = tmp_path / "out"
-    cfg_path.write_text(textwrap.dedent(f"""
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""
         raster_path: "{synthetic_raster}"
         climate_csv: "{synthetic_climate_csv}"
         output_dir: "{out_dir}"
@@ -379,7 +385,9 @@ def test_resolve_run_dir_returns_deterministic_path(
           w_v: 0.4
           w_t: 0.3
           w_r: 0.3
-    """))
+    """
+        )
+    )
 
     run_dir = resolve_run_dir(cfg_path)
     assert run_dir.name  # fingerprint is non-empty

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -47,7 +47,8 @@ def _write_kriging_config(
     out_dir: Path,
     uncertainty_samples: int = 0,
 ) -> Path:
-    cfg = textwrap.dedent(f"""
+    cfg = textwrap.dedent(
+        f"""
         raster_path: "{raster}"
         climate_csv: "{climate}"
         output_dir: "{out_dir}"
@@ -76,7 +77,8 @@ def _write_kriging_config(
           interpolation_method: "kriging"
 
         max_cells: 5
-    """)
+    """
+    )
     cfg_file.write_text(cfg, encoding="utf-8")
     return cfg_file
 
@@ -88,7 +90,8 @@ def _write_linear_config(
     out_dir: Path,
     uncertainty_samples: int = 200,
 ) -> Path:
-    cfg = textwrap.dedent(f"""
+    cfg = textwrap.dedent(
+        f"""
         raster_path: "{raster}"
         climate_csv: "{climate}"
         output_dir: "{out_dir}"
@@ -117,7 +120,8 @@ def _write_linear_config(
           interpolation_method: "linear"
 
         max_cells: 5
-    """)
+    """
+    )
     cfg_file.write_text(cfg, encoding="utf-8")
     return cfg_file
 


### PR DESCRIPTION
## Summary
- add `variogram_mode` support for kriging and evaluate nested extended variogram candidates with LOOCV reporting
- tighten ROI clipping to pixel-snapped intersecting windows and add a regression test for sub-1% ROI reads
- document the new kriging configuration and extend coverage in config, geo, climate, and pipeline tests

## Why
Issue #35 asks for an extended kriging candidate set with reportable LOOCV diagnostics.
Issue #36 asks for tighter windowed raster reads and explicit coverage for very small ROIs.

## Validation
- `pytest tests/test_config.py tests/test_geo.py tests/test_climate.py -q`

Closes #35
Closes #36