### PR TITLE
fix(ci): docker-smoke cleanup — handle root-owned volume files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,8 @@ docker-smoke:
 	docker build -t terraflow:latest .
 	@set -e; \
 	out=$$(mktemp -d 2>/dev/null || mktemp -d -t terraflow-smoke); \
-	trap 'rm -rf "$$out"' EXIT; \
+	cleanup() { docker run --rm -v "$$out":/cleanup alpine:3 sh -c 'rm -rf /cleanup/*' 2>/dev/null || true; rmdir "$$out" 2>/dev/null || true; }; \
+	trap cleanup EXIT; \
 	echo "Running demo pipeline in docker with --network none..."; \
 	docker run --rm --network none \
 		-v "$$out":/app/outputs \


### PR DESCRIPTION
The docker-smoke-offline CI job on v0.3.0 failed at cleanup even though the smoke itself succeeded. Bind-mounted artifacts are written as root inside the container; the previous `rm -rf` in the EXIT trap ran as the runner user and hit 'Permission denied'.

Cleanup now runs a throwaway alpine container against the same mount to remove the files, then `rmdir`s the empty host dir; errors are swallowed so the target's exit code reflects the smoke, not the cleanup.

## Test plan
- [x] `make docker-smoke` succeeds locally with exit code 0
- [ ] CI green