### PR TITLE
fix(security): address SonarCloud Quality Gate issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Build Docker image
         run: docker build -t terraflow:ci .
 
+      - name: Prepare output directory
+        run: |
+          mkdir -p docker-out
+          # Container runs as uid 1001 (terraflow user); match host ownership
+          sudo chown -R 1001:1001 docker-out
+
       - name: Run demo pipeline end-to-end
         run: |
           docker run --rm \

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -16,11 +16,6 @@ on:
         required: false
         default: "false"
 
-permissions:
-  contents: write
-  pull-requests: write
-  deployments: write
-
 concurrency:
   group: docs-preview-${{ github.event.number || 'prune' }}
   cancel-in-progress: true
@@ -29,6 +24,10 @@ jobs:
   preview:
     if: github.event_name == 'pull_request' && (github.event.inputs.prune_only != 'true')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      deployments: write
     environment:
       name: Pages Preview
       url: https://terraflow.marupilla.dev/runs/${{ github.run_id }}/
@@ -89,6 +88,8 @@ jobs:
   prune:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,6 @@ on:
       - "mkdocs.yml"
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
   group: gh-pages-deploy
   cancel-in-progress: true
@@ -19,6 +16,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -42,8 +42,10 @@ jobs:
           echo "SHA256: ${SHA}"
 
       - name: Clone tap repo
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          git clone "https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/gmarupilla/homebrew-terraflow.git" tap-repo
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/gmarupilla/homebrew-terraflow.git" tap-repo
 
       - name: Update formula
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,14 +9,13 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   dependency-review:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,6 +26,8 @@ jobs:
   license-check:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -57,6 +58,8 @@ jobs:
   pip-audit:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN python scripts/make_demo_raster.py
 # Pipeline writes here at runtime
 RUN mkdir -p outputs
 
+# Run as non-root user
+RUN groupadd --system --gid 1001 terraflow && \
+    useradd --system --uid 1001 --gid terraflow --home-dir /app --shell /sbin/nologin terraflow && \
+    chown -R terraflow:terraflow /app
+USER terraflow
+
 # Default: run the demo pipeline; override --config for custom runs
 ENTRYPOINT ["python", "-m", "terraflow.cli"]
 CMD ["run", "--config", "examples/demo_config.yml"]

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -153,8 +153,8 @@ class TestClimateInterpolatorInit:
 
         assert len(interpolator.climate_df) == 2
         merged_row = interpolator.climate_df[
-            (interpolator.climate_df["lat"] == 40.0)
-            & (interpolator.climate_df["lon"] == -74.0)
+            np.isclose(interpolator.climate_df["lat"], 40.0)
+            & np.isclose(interpolator.climate_df["lon"], -74.0)
         ].iloc[0]
         assert merged_row["mean_temp"] == pytest.approx(16.0)
         assert "Resolved 2 duplicate station row(s)" in caplog.text
@@ -172,8 +172,8 @@ class TestClimateInterpolatorInit:
 
         interpolator = ClimateInterpolator(climate_df=climate_df)
 
-        assert interpolator._climate_mean["mean_temp"] == 20.0
-        assert interpolator._climate_mean["total_rain"] == 200.0
+        assert interpolator._climate_mean["mean_temp"] == pytest.approx(20.0)
+        assert interpolator._climate_mean["total_rain"] == pytest.approx(200.0)
 
 
 class TestDuplicateStationKriging:
@@ -360,9 +360,9 @@ class TestClimateInterpolatorIndex:
 
         # Should match rows 0, 1, 2 from climate_df (ignoring input coords)
         assert len(result) == 3
-        assert result["mean_temp"].iloc[0] == 10.0
-        assert result["mean_temp"].iloc[1] == 15.0
-        assert result["mean_temp"].iloc[2] == 20.0
+        assert result["mean_temp"].iloc[0] == pytest.approx(10.0)
+        assert result["mean_temp"].iloc[1] == pytest.approx(15.0)
+        assert result["mean_temp"].iloc[2] == pytest.approx(20.0)
 
     def test_index_fewer_climate_records_with_fallback(self):
         """Fewer climate records than cells with fallback."""
@@ -386,10 +386,10 @@ class TestClimateInterpolatorIndex:
 
         assert len(result) == 4
         # First 2 from climate data, last 2 from mean
-        assert result["mean_temp"].iloc[0] == 10.0
-        assert result["mean_temp"].iloc[1] == 20.0
-        assert result["mean_temp"].iloc[2] == 15.0  # Fallback
-        assert result["mean_temp"].iloc[3] == 15.0  # Fallback
+        assert result["mean_temp"].iloc[0] == pytest.approx(10.0)
+        assert result["mean_temp"].iloc[1] == pytest.approx(20.0)
+        assert result["mean_temp"].iloc[2] == pytest.approx(15.0)  # Fallback
+        assert result["mean_temp"].iloc[3] == pytest.approx(15.0)  # Fallback
 
     def test_index_more_climate_records_than_cells(self):
         """More climate records than cells (takes first N for index matching)."""
@@ -449,7 +449,7 @@ class TestLoadClimateCSV:
 
         assert len(df) == 1
         assert list(df.columns) == ["lat", "lon", "mean_temp", "total_rain"]
-        assert df["lat"].iloc[0] == 40.0
+        assert df["lat"].iloc[0] == pytest.approx(40.0)
 
     def test_load_csv_missing_file_raises_error(self):
         """Missing file raises FileNotFoundError."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,7 +33,7 @@ def test_load_config_tmp(tmp_path: Path):
 
     cfg = load_config(cfg_file)
     assert cfg.raster_path.name == "usda_cdl.tif"
-    assert cfg.model_params.w_v == 0.4
+    assert cfg.model_params.w_v == pytest.approx(0.4)
     assert cfg.roi.type == "bbox"
 
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -301,9 +301,9 @@ def test_clip_raster_selects_requested_band(tmp_path: Path):
         data_b1, _ = clip_raster_to_roi(src, roi, band=1)
         data_b2, _ = clip_raster_to_roi(src, roi, band=2)
         data_b3, _ = clip_raster_to_roi(src, roi, band=3)
-    assert np.all(data_b1 == 10.0)
-    assert np.all(data_b2 == 20.0)
-    assert np.all(data_b3 == 30.0)
+    assert np.allclose(data_b1, 10.0)
+    assert np.allclose(data_b2, 20.0)
+    assert np.allclose(data_b3, 30.0)
 
 
 def test_clip_raster_out_of_range_band_raises(tmp_path: Path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -224,8 +224,8 @@ def test_aggregate_climate_means():
 
     result = _aggregate_climate(df)
 
-    assert result["mean_temp"] == 12.0
-    assert result["total_rain"] == 110.0
+    assert result["mean_temp"] == pytest.approx(12.0)
+    assert result["total_rain"] == pytest.approx(110.0)
 
 
 def test_aggregate_climate_missing_columns():

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -40,9 +40,9 @@ def test_raster_summary_from_array_basic():
     summary = RasterSummary.from_array(arr)
 
     assert summary.count == 4
-    assert summary.mean == 2.5
-    assert summary.min == 1.0
-    assert summary.max == 4.0
+    assert summary.mean == pytest.approx(2.5)
+    assert summary.min == pytest.approx(1.0)
+    assert summary.max == pytest.approx(4.0)
     assert summary.std is not None
 
 
@@ -51,7 +51,7 @@ def test_raster_summary_single_value_std_zero():
     summary = RasterSummary.from_array(arr)
 
     assert summary.count == 1
-    assert summary.std == 0.0
+    assert summary.std == pytest.approx(0.0)
 
 
 def test_summarize_raster_and_file(tmp_path: Path):
@@ -62,8 +62,8 @@ def test_summarize_raster_and_file(tmp_path: Path):
         summary = summarize_raster(ds)
 
     assert summary.count == 9
-    assert summary.min == 0.0
-    assert summary.max == 8.0
+    assert summary.min == pytest.approx(0.0)
+    assert summary.max == pytest.approx(8.0)
 
     summary2 = summarize_raster_file(raster_path)
     assert summary2.count == summary.count
@@ -96,8 +96,8 @@ def test_compare_rasters_ratio(tmp_path: Path):
         ratio, summary = compare_rasters(ds_a, ds_b, mode="ratio")
 
     assert np.allclose(ratio.compressed(), 0.5)
-    assert summary.min == 0.5
-    assert summary.max == 0.5
+    assert summary.min == pytest.approx(0.5)
+    assert summary.max == pytest.approx(0.5)
 
 
 def test_compare_rasters_shape_mismatch(tmp_path: Path):
@@ -131,5 +131,5 @@ def test_batch_summarize(tmp_path: Path):
     summaries = batch_summarize([path_a, path_b])
 
     assert set(summaries.keys()) == {"alpha", "beta"}
-    assert summaries["alpha"].mean == 1.0
-    assert summaries["beta"].mean == 3.0
+    assert summaries["alpha"].mean == pytest.approx(1.0)
+    assert summaries["beta"].mean == pytest.approx(3.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,12 @@
+import pytest
+
 from terraflow.utils import normalize
 
 
 def test_normalize_clamps_out_of_range():
-    assert normalize(150, 0, 100) == 1.0
-    assert normalize(-10, 0, 100) == 0.0
+    assert normalize(150, 0, 100) == pytest.approx(1.0)
+    assert normalize(-10, 0, 100) == pytest.approx(0.0)
 
 
 def test_normalize_zero_range():
-    assert normalize(10, 5, 5) == 0.0
+    assert normalize(10, 5, 5) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

Addresses SonarCloud Quality Gate failures on `main`:
- **15 Security Hotspots** (1 Dockerfile root + 13 workflow SHA-pin + 1 secret expansion)
- **C Security Rating on New Code** (5 workflow permission vulnerabilities — S8233/S8264)
- **C Reliability Rating on New Code** (33 float-equality bugs in tests — S1244)

## Changes

- **Dockerfile**: add `terraflow` non-root user (UID 1001) — addresses `docker:S6471`
- **publish-homebrew.yml**: pass `HOMEBREW_TAP_TOKEN` via `env:` instead of inline `${{ secrets.X }}` in `run:` — addresses `githubactions:S7636`
- **docs.yml, docs-preview.yml, quality.yml**: move `permissions:` from workflow-level to job-level (principle of least privilege) — addresses `githubactions:S8233`, `S8264`
- **tests/** (6 files): replace `==` on floats with `pytest.approx()` / `np.isclose()` — addresses `python:S1244` (33 occurrences)

## Not addressed (requires SonarCloud UI action)

13 `githubactions:S7637` hotspots ("use full commit SHA for action reference"). All are trusted `actions/*` or well-known third-party (`astral-sh/setup-uv`, `SonarSource/sonarcloud-github-action`, `codecov/codecov-action`). Recommend bulk-marking as **SAFE** in SonarCloud UI with justification: "Trusted publisher, Dependabot-managed version pins."

## Test plan

- [x] `pytest -q` → 231 passed, 1 skipped
- [x] `ruff check tests/` → clean
- [x] `black --check tests/` → clean
- [ ] SonarCloud Quality Gate passes on this PR
- [ ] After merge: mark 13 S7637 workflow-SHA hotspots SAFE in SonarCloud UI