### PR TITLE
docs: align README, CLAUDE.md, mkdocs, and API docs with v0.3.0 code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Version is declared in **two places** — both must be updated together:
 - `pyproject.toml` line `version = "X.Y.Z"`
 - `terraflow/__init__.py` `__version__ = "X.Y.Z"`
 
-Project follows [Semantic Versioning](https://semver.org). Current version: `0.2.2`.
+Project follows [Semantic Versioning](https://semver.org). Current version: `0.3.0`.
 
 ### Release steps
 
@@ -197,7 +197,8 @@ docs/
     ├── kriging_uncertainty_demo.ipynb
     ├── 02_sensitivity_analysis.ipynb
     ├── 03_model_validation.ipynb
-    └── 04_h3_export.ipynb
+    ├── 04_h3_export.ipynb
+    └── 05_extended_variogram_mode.ipynb
 ```
 
 When adding a new page: create the `.md` file, add it to `mkdocs.yml` nav, and

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ TerraFlow is a reproducible, config-driven geospatial workflow for agricultural 
 
 ---
 
+## At a Glance
+
+```mermaid
+flowchart LR
+    CFG["Config<br/>(YAML + Pydantic)"] --> PIPE["Pipeline<br/>(orchestration)"]
+    PIPE --> ING["Ingest<br/>(raster, climate)"]
+    PIPE --> GEO["Geospatial<br/>(ROI clipping)"]
+    PIPE --> MOD["Model<br/>(suitability scoring)"]
+    PIPE --> OUT["Outputs<br/>(Parquet, CSV,<br/>manifest, report)"]
+    ING --> GEO
+    ING --> MOD
+    GEO --> MOD
+```
+
+| Property | What TerraFlow guarantees |
+|---|---|
+| **Deterministic outputs** | Same config + same inputs → bit-identical results, addressed by run fingerprint |
+| **Provenance** | Every run writes a `manifest.json` capturing config, input hashes, software versions, and fingerprint |
+| **Spatial validation** | Spatial-block CV with Cohen's κ + Moran's I on residuals (`terraflow validate`) |
+| **Sensitivity analysis** | Sobol' / Morris indices for model weights (`terraflow sensitivity`) |
+| **Uncertainty quantification** | Kriging Monte Carlo → score CIs (`score_ci_low` / `score_ci_high`) |
+| **Interop** | H3-indexed export for downstream tools (`terraflow export --format h3`) |
+| **Distribution** | PyPI (`terraflow-agro`) + Homebrew (`gmarupilla/terraflow`) + Docker |
+| **Citation** | Citable via `CITATION.cff`; JOSS paper in preparation |
+
+---
+
 ## Installation
 
 **macOS (Homebrew)** — handles GDAL and PROJ automatically:
@@ -45,7 +72,7 @@ See [Homebrew install docs](https://terraflow.marupilla.dev/install/homebrew/) f
 ## Quickstart
 
 ```bash
-terraflow --config config.yml
+terraflow run --config config.yml
 ```
 
 A minimal config:
@@ -128,9 +155,11 @@ make docs-build
 
 ## Architecture
 
-Core modules: `cli`, `config`, `climate`, `geo`, `ingest`, `model`, `pipeline`, `stats`, `viz`.
+Core modules: `cli`, `config`, `climate`, `core/run_identity`, `exceptions`, `export`, `geo`, `ingest`, `model`, `pipeline`, `sensitivity`, `stats`, `utils`, `validation`, `viz`.
 
-Key design decisions are documented in Architecture Decision Records under `docs/architecture/`.
+Run artifacts under `<output_dir>/runs/<fingerprint>/` include `features.parquet`, `manifest.json`, `report.json`, and `results.csv`. When kriging is configured, `report.json` also carries `kriging_diagnostics` (model, nugget, sill, range), `kriging_loocv` RMSE per variable, `uncertainty` coverage, and an `interpolation_fallback` block with per-variable fallback-to-mean counts. Multi-band rasters are supported via the top-level `raster_band` field (1-based; default `1`).
+
+Key design decisions are documented in Architecture Decision Records under `docs/architecture/`. See [`docs/reproducibility.md`](https://terraflow.marupilla.dev/reproducibility/) for the run fingerprint contract and known sources of non-determinism.
 
 ## Project Scope
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,313 +1,86 @@
 ---
 title: Roadmap
-description: Strategic direction for TerraFlow — completed tracks, planned v1.0 features, and future production capabilities.
+description: TerraFlow phased roadmap to JOSS submission — completed phases, active phase, and v2 ideas.
 icon: material/road-variant
 tags:
   - Development
   - Reference
 ---
 
-# TerraFlow Feature Roadmap
+# TerraFlow Roadmap
 
-Last Updated: 2026-02-06
+This roadmap mirrors `.planning/ROADMAP.md` (the single source of truth for in-flight work). The work from here to JOSS submission is additive: close two reviewer-visible gaps in the foundation (CRS errors, kriging diagnostics), add three analytical modules (sensitivity, validation, H3 export) as post-pipeline adapters, then finalize the paper with quantitative results drawn from those modules.
 
-## Overview
+JOSS submission target: **2026-05-25**.
 
-This document outlines the strategic direction for TerraFlow development, organized by priority and implementation complexity. Features are grouped into three main tracks:
+## Phase Status
 
-<div class="grid" markdown>
+| Phase | Plans | Status | Completed |
+|-------|-------|--------|-----------|
+| 1. Foundation Hardening | mostly delivered in 0.2.x — 0.3.0 | Released | 2026-04-23 (v0.3.0) |
+| 2. Sensitivity Analysis | 3/3 | Complete | 2026-03-28 |
+| 3. Model Validation | 3/3 | Complete | 2026-03-31 |
+| 4. H3 Export | 3/3 | Complete | 2026-04-04 |
+| 5. Paper and JOSS Submission | in flight | Active | — |
 
-:material-check-circle:{ .lg .middle style="color: #00c853" } **Track 1: Stability & Quality** <span class="status-completed">COMPLETED</span>
-:   Reliability, testability, and maintainability improvements
+## Phase 1 — Foundation Hardening
 
-:material-check-circle:{ .lg .middle style="color: #00c853" } **Track 2: Capability Expansion** <span class="status-completed">v0.2.0 RELEASED</span>
-:   Per-cell climate interpolation and enhanced data support
+Close the CRS error and kriging diagnostic gaps that block JOSS reviewer acceptance.
 
-:material-timer-sand:{ .lg .middle style="color: #00b0ff" } **Track 3: Production Features** <span class="status-planned">v1.0 PLANNED</span>
-:   Progress tracking, fingerprinting, and operational deployment
+**Delivered (v0.2.2 / v0.3.0):**
 
-</div>
+- `CRSMismatchError` raised with both CRS strings when raster and ROI CRS disagree.
+- `kriging_diagnostics` block in `report.json` — model name, psill, nugget, sill, range, range units.
+- `kriging_loocv` RMSE in `report.json` per kriged climate variable.
+- `plotly` demoted to optional `[viz]` extra; trove classifiers + Documentation URL added to `pyproject.toml`.
+- `interpolation_fallback` block in `report.json` with per-variable fallback-to-mean counts plus aggregate total (v0.3.0).
+- Coverage floor maintained at 85 % branch coverage with kriging-fallback and Monte-Carlo edge-case tests.
 
----
+## Phase 2 — Sensitivity Analysis ✓
 
-## Track 1: Stability & Quality <span class="status-completed">✅ COMPLETED</span>
+Sobol' first-order / total-order indices and Morris elementary effects for `ModelParams` weights via SALib. Invoked with `terraflow sensitivity -c config.yml`. Results written to `sensitivity_report.json`.
 
-Features completed in this phase improve reliability, testability, and maintainability.
+## Phase 3 — Model Validation ✓
 
-!!! success "Fully Implemented"
-    All features in this track have been completed and released in v0.1.x series.
+Spatial block cross-validation (Roberts et al. 2017), Cohen's kappa, and Moran's I on residuals. Invoked with `terraflow validate -c config.yml`. Results appended to `report.json` under the `validation` key.
 
-### ✅ Resource Management
-- [x] Fix unclosed rasterio file handles (resource leak)
-- [x] Implement proper context manager patterns
-- [x] Add resource cleanup tests
+## Phase 4 — H3 Export ✓
 
-### ✅ Error Handling & Validation
-- [x] File existence validation before operations
-- [x] ROI bounds validation (min < max)
-- [x] Raster band count validation
-- [x] Model parameter range validation (v_min < v_max, etc.)
-- [x] Climate CSV column validation
-- [x] Configuration file validation with helpful error messages
-- [x] Fix overly broad exception handling (bare `except`)
+Optional H3-indexed output for interop with H3-native toolchains. `terraflow export --format h3 -c config.yml` writes `h3_resolution_N.parquet` to the run directory. `h3-py` is an optional dep installed via `pip install terraflow-agro[h3]`.
 
-### ✅ Testing
-- [x] CLI unit tests (arguments, errors, help)
-- [x] Error path tests (missing files, invalid configs)
-- [x] Geo module edge case tests (invalid bounds, non-intersecting ROI)
-- [x] Ingest module tests (file validation, malformed data)
-- [x] Test coverage for 14 critical scenarios
+## Phase 5 — Paper and JOSS Submission (Active)
 
-### ✅ Documentation
-- [x] Comprehensive module docstrings
-- [x] Function parameter/return/exception documentation
-- [x] Architecture Decision Records (ADRs)
-- [x] CLI help text with examples
+**Goal:** the paper contains quantitative results drawn from the prior phases, packaging meets JOSS reviewer requirements, and the repository passes an end-to-end smoke test without network access.
 
-### ✅ Dependencies
-- [x] Remove unused imports (xarray, geopandas)
-- [x] Add version constraints for reproducibility
-- [x] Sync package version (0.2.0) across pyproject.toml and __init__.py
+Active work:
 
-### ✅ Code Quality
-- [x] Fix spatial sampling bias (random.sample vs list slicing)
-- [x] Improve logging messages with context
-- [x] Add validation hooks in Pydantic models
+- `paper/paper.md` reproducibility section — quantitative results table populated from a full demo run (v0.3.0).
+- `paper/biblio.bib` — SALib (Herman & Usher 2017), Saltelli et al. (2008), Cressie (1993) entries with DOIs (v0.3.0).
+- `make docker-smoke` — Docker pipeline runs with `--network none`, asserted in CI via `docker-smoke-offline` job (v0.3.0).
+- Final pass on submission date and version string sync between `paper/paper.md` and the PyPI release.
 
----
+## v2 Ideas
 
-## Track 2: Capability Expansion <span class="status-completed">✅ v0.2.0 RELEASED</span>
+These are not planned for v1 (not on the JOSS critical path) but are worth tracking:
 
-Features that add significant value while maintaining focus on agricultural modeling.
+- **Directional variograms** for spatial anisotropy detection (scikit-gstat).
+- **Universal Kriging** with elevation covariates.
+- **UTM-projected variograms** for high-latitude fits.
+- **STAC / COG** ingestion for cloud-native rasters.
+- **Polygon ROI** support (shapefile / GeoJSON).
+- **Data-driven weight learning** from labeled training points.
 
-!!! success "Enhanced Climate Data Support (v0.2.0)"
-    Per-cell climate interpolation is now fully implemented with two configurable strategies:
-    
-    - ✅ Spatial interpolation using `scipy.interpolate.griddata`
-    - ✅ Index-based matching for pre-aligned data
-    - ✅ Graceful fallback to global mean for sparse data
-    - ✅ Comprehensive validation and 32 test cases
-    - ✅ Full documentation and ADR-003
+## Out of Scope
 
-### 📌 Progress Tracking & Observability <span class="status-planned">v1.0 PLANNED</span>
-
-**Goal**: Users can monitor long-running jobs and understand what's happening.
-
-!!! example "Planned Features"
-    **Progress bar**: Show sampling progress for large ROIs
-    ```
-    Sampling cells: [████████░░] 80/100
-    ```
-    
-    **Runtime estimation**: Predict total time based on raster size  
-    **Sampling statistics**: Valid cell count, sampling ratio, geographic extent
-
-**Implementation**: `pipeline.py` | **Effort**: 4-6 hours | **Tests**: Progress accuracy, timeout handling
-
----
-
-### 📌 Run Fingerprinting & Reproducibility <span class="status-planned">v1.0 PLANNED</span>
-
-**Goal**: Track inputs/outputs for reproducibility and auditing.
-
-!!! example "Manifest File"
-    Generate `manifest.json` with complete provenance tracking:
-    
-    ```json
-    {
-      "version": "0.2.0",
-      "timestamp": "2026-02-06T14:30:00Z",
-      "config_hash": "sha256:abc123...",
-      "raster_hash": "sha256:def456...",
-      "sampled_cells": 500,
-      "execution_time_seconds": 12.34
-    }
-    ```
-
-**Implementation**: `utils.py`, `pipeline.py`, new `fingerprint.py` | **Effort**: 6-8 hours
-
----
-1. Keep rasterio window-based reads
-2. Process in overlapping windows with stride
-3. Write batches to parquet file
-4. Return summary stats instead of full DataFrame
-
-**Implementation Files**: `pipeline.py`, new `output.py`
-**Estimated Effort**: 12-16 hours
-**Tests Required**: Memory usage, output consistency vs current approach
-**Dependencies**: `pyarrow` (for parquet)
-
----
-
-### 📌 Multi-Band Raster Support (Priority: MEDIUM)
-
-**Goal**: Process multi-band data and create composite models.
-
-#### Features
-- **Band selection**: Config parameter `band: 1` (default) or `bands: [1, 2, 3]`
-- **Composite scoring**: Combine multiple band indices
-  - Weighted average: `score = 0.4*ndvi + 0.3*evi + 0.3*moisture`
-  - Separate models: Run different model params per band
-  
-- **Auto-detection**: Recognize common indices from metadata
-  - NDVI, EVI, NDBI, etc.
-  
-**Implementation Files**: `config.py`, `geo.py`, `model.py`
-**Estimated Effort**: 10-12 hours
-**Tests Required**: Band validation, multi-band aggregation
-**Related ADR**: See [adr-001-band-selection.md](architecture/adr-001-band-selection.md)
-
----
-
-### 📌 Polygon ROI Support (Priority: MEDIUM)
-
-**Goal**: Support arbitrary polygon regions of interest (state boundaries, farms, etc.).
-
-#### Current Limitation
-- Only bounding box (4 parameters) supported
-- Users with irregular regions must pre-process
-
-#### Proposed Features
-- **GeoJSON input**: Specify ROI as GeoJSON polygon
-- **Shapefile support**: Load from .shp/.gpkg files
-- **Named regions**: Integrate with GADM or similar
-- **Boundary buffering**: Expand point locations to study areas
-
-#### Implementation Strategy
-1. Read polygon geometry via fiona/geopandas
-2. Rasterize polygon to create mask
-3. Apply mask to clipped raster
-4. Continue normal pipeline
-
-**Implementation Files**: `config.py`, `geo.py`, new `polygon.py`
-**Estimated Effort**: 10-14 hours
-**Tests Required**: Polygon accuracy, rasterization edge cases
-**Dependencies**: `fiona` or `geopandas` (optional)
-**Related ADR**: See [adr-002-bbox-roi.md](architecture/adr-002-bbox-roi.md)
-
----
-
-## Track 3: Production Features (FUTURE)
-
-Features for operational deployment, monitoring, and integration.
-
-### 🎯 Cloud-Native Integration
-
-- **S3/GCS input**: Read rasters directly from cloud storage
-- **COG support**: Optimize for Cloud-Optimized GeoTIFF reads
-- **Cloud output**: Write results to cloud blob storage
-- **Distributed processing**: Support Spark/Dask for parallel regions
-
-**Estimated Effort**: 20+ hours
-**Priority**: Q3 2026+
-
----
-
-### 🎯 Web Service & API
-
-- **REST API**: Flask/FastAPI endpoint for running pipeline
-- **Job queuing**: Background task processing (Celery)
-- **Web UI**: Interactive map for ROI selection
-- **Authentication**: API key management for hosted instance
-
-**Estimated Effort**: 40+ hours
-**Priority**: Q4 2026+
-
----
-
-### 🎯 Temporal Analysis
-
-- **Time series**: Process multiple rasters across time
-- **Trend detection**: Identify suitability changes over seasons/years
-- **Phenology**: Track seasonal crop development
-- **Anomaly detection**: Identify unusual years/regions
-
-**Estimated Effort**: 24-30 hours
-**Priority**: Q3 2026+
-
----
-
-### 🎯 Model Enhancements
-
-- **Machine learning**: Learn weights from training data instead of manual specification
-- **Bayesian uncertainty**: Quantify confidence in scores
-- **Sensitivity analysis**: Identify which factors matter most
-- **Custom indices**: Let users define new vegetation/climate indices
-
-**Estimated Effort**: 30+ hours
-**Priority**: Q4 2026+
-
----
-
-### 🎯 Validation & Benchmarking
-
-- **Cross-validation**: Leave-one-out or k-fold validation on known sites
-- **Uncertainty bounds**: Confidence intervals around predictions
-- **Comparison mode**: Compare results across model versions
-- **Performance profiling**: Benchmark against standard datasets
-
-**Estimated Effort**: 12-18 hours
-**Priority**: Q2 2026
-
----
-
-## Implementation Timeline
-
-```
-v0.2.0 (Q1 2026)
-├─ Progress tracking ✓
-├─ Large raster optimization ✓
-├─ Enhanced climate support ✓
-└─ Run fingerprinting ✓
-
-v1.0.0 (Q2 2026)
-├─ Multi-band support ✓
-├─ Polygon ROI ✓
-├─ Comprehensive tests ✓
-└─ Production documentation ✓
-
-v1.1.0 (Q3 2026)
-├─ Cloud integration ✓
-├─ Temporal analysis ✓
-└─ Validation framework ✓
-
-v2.0.0 (Q4 2026)
-├─ Web API ✓
-├─ ML models ✓
-└─ Advanced analytics ✓
-```
-
----
-
-## Community Contribution Opportunities
-
-Areas well-suited for external contributions:
-
-1. **Integration tests** for different raster types (GeoTIFF, COG, NetCDF)
-2. **Documentation** improvements and examples
-3. **UI/visualization** enhancements
-4. **Cloud provider adapters** (AWS, GCP, Azure)
-5. **Model examples** for specific crops/regions
-6. **Performance optimization** for specific hardware
-
----
-
-## Decision Framework
-
-For new features, consider:
-
-1. **Alignment**: Does it serve agricultural modeling use cases?
-2. **Simplicity**: Can it be explained in <5 minutes?
-3. **Testability**: Can the feature be rigorously tested?
-4. **Maintenance**: What's the ongoing support burden?
-5. **Dependencies**: Do new libraries add value?
-
----
+| Feature | Reason |
+|---|---|
+| Web UI or dashboard | Library-first; visualization is the caller's responsibility. |
+| Streaming / real-time ingestion | Batch pipeline; streaming adds complexity without research value. |
+| Commercial ag operations tooling | Focus is the research community. |
+| Non-Python client SDKs | Python-first for v1. |
 
 ## References
 
 - [Architecture Overview](architecture/overview.md)
-- [ADR-001: Band Selection](architecture/adr-001-band-selection.md)
-- [ADR-002: ROI Type](architecture/adr-002-bbox-roi.md)
 - [Configuration Schema](config/schema.md)
-
+- [Reproducibility](reproducibility.md)

--- a/docs/api/export.md
+++ b/docs/api/export.md
@@ -1,0 +1,21 @@
+---
+title: Export API
+description: API reference for terraflow.export — H3-indexed output for downstream interop.
+icon: material/hexagon-multiple
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.export
+
+Re-indexes pipeline output to H3 hexagonal cells for interop with DeckGL, Kepler.gl, and h3pandas. The `h3-py` dependency is optional — install with `pip install terraflow-agro[h3]`.
+
+## Public surface
+
+- `to_h3(features, resolution=8)` — convert a `features` DataFrame to an H3-indexed structure.
+- `run_export(config, ...)` — orchestrator used by `terraflow export --format h3`.
+
+## API Reference
+
+::: terraflow.export

--- a/docs/api/geo.md
+++ b/docs/api/geo.md
@@ -1,0 +1,22 @@
+---
+title: Geo API
+description: API reference for terraflow.geo — ROI clipping, CRS reprojection, and pixel-window helpers.
+icon: material/earth
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.geo
+
+The geo module owns ROI clipping and CRS alignment. The pipeline invariant is **all output coordinates are EPSG:4326** — `geo.py` reprojects any input that differs.
+
+## Overview
+
+- ROI bounds in any CRS are reprojected to the raster CRS (all four corners, then axis-aligned bounding box) before windowing.
+- ROI clipping snaps requested bounds to an intersecting pixel window so very small ROIs avoid oversized raster reads.
+- Degenerate windows (NaN dimensions after reprojection) raise `ValueError` with diagnostic context.
+
+## API Reference
+
+::: terraflow.geo

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -1,0 +1,22 @@
+---
+title: Model API
+description: API reference for terraflow.model — suitability scoring and label assignment.
+icon: material/calculator-variant
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.model
+
+Suitability scoring is a normalized weighted composite of vegetation index, mean temperature, and total rainfall. Scores in `[0, 1]` are mapped to ordinal labels.
+
+## Public functions
+
+- `suitability_score(v, t, r, params)` — single-cell scalar score.
+- `suitability_score_array(v, t, r, params)` — vectorised NumPy version used by the pipeline.
+- `suitability_label(score)` — score → ordinal class.
+
+## API Reference
+
+::: terraflow.model

--- a/docs/api/sensitivity.md
+++ b/docs/api/sensitivity.md
@@ -1,0 +1,16 @@
+---
+title: Sensitivity API
+description: API reference for terraflow.sensitivity — Sobol' / Morris analysis via SALib.
+icon: material/chart-scatter-plot
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.sensitivity
+
+Sobol' first-order / total-order indices and Morris elementary effects for `ModelParams` weights. Invoked from the CLI as `terraflow sensitivity -c config.yml`; results land in `sensitivity_report.json` in the run directory.
+
+## API Reference
+
+::: terraflow.sensitivity

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -1,0 +1,21 @@
+---
+title: Stats API
+description: API reference for terraflow.stats — Pydantic summary models and raster/climate stat helpers.
+icon: material/chart-bar
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.stats
+
+The stats module exposes the Pydantic summary models that back `report.json` plus helper functions for raster and climate statistics.
+
+## Public surface
+
+- `RasterSummary`, `ClimateSummary`, `RunReport` — Pydantic v2 models.
+- `summarize_raster`, `summarize_raster_file`, `compare_rasters`, `batch_summarize` — helper functions.
+
+## API Reference
+
+::: terraflow.stats

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,0 +1,16 @@
+---
+title: Validation API
+description: API reference for terraflow.validation — spatial block CV, Cohen's kappa, and Moran's I.
+icon: material/check-decagram
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.validation
+
+Spatial block cross-validation (Roberts et al. 2017), Cohen's kappa against an optional reference CSV, and Moran's I on score residuals. Invoked from the CLI as `terraflow validate -c config.yml`; results are appended to `report.json` under the `validation` key.
+
+## API Reference
+
+::: terraflow.validation

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -16,7 +16,7 @@ TerraFlow exposes a lightweight CLI for running the pipeline.
 === "Direct CLI"
 
     ```bash
-    terraflow --config path/to/config.yml
+    terraflow run --config path/to/config.yml
     ```
 
     The command will:
@@ -28,17 +28,17 @@ TerraFlow exposes a lightweight CLI for running the pipeline.
 === "Python Module"
 
     ```python
-    from terraflow.pipeline import main
-    
+    from terraflow.pipeline import run_pipeline
+
     # Run the pipeline programmatically
-    main("path/to/config.yml")
+    run_pipeline("path/to/config.yml")
     ```
 
 === "Without Install"
 
     ```bash
     # Use python -m fallback (no install required)
-    python -m terraflow.cli --config path/to/config.yml
+    python -m terraflow.cli run --config path/to/config.yml
     ```
 
 !!! tip "Portable Configs"
@@ -132,3 +132,18 @@ Results are appended to the existing `report.json` under the `"validation"` key:
     TerraFlow's suitability model has no free parameters — scores are deterministic given the config. Fold accuracy reflects how spatially consistent the label distribution is across your study area, not model generalization.
 
 See [`notebooks/03_model_validation.ipynb`](../notebooks/03_model_validation.ipynb) for a worked example.
+
+## H3 export
+
+Re-index pipeline output to H3 hexagonal cells for interop with DeckGL, Kepler.gl, and h3pandas. Requires the optional `[h3]` extra:
+
+```bash
+pip install terraflow-agro[h3]
+terraflow export --format h3 -c config.yml
+# or pass an explicit resolution override:
+terraflow export --format h3 -c config.yml --resolution 8
+```
+
+The output `h3_resolution_N.parquet` lands in the run directory alongside `features.parquet`. The H3 resolution participates in the run fingerprint, so different resolutions produce distinct cached artifacts.
+
+See [`notebooks/04_h3_export.ipynb`](../notebooks/04_h3_export.ipynb) and the [H3 export guide](../h3-export.md) for a worked example.

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -42,7 +42,7 @@ TerraFlow exposes a lightweight CLI for running the pipeline.
     ```
 
 !!! tip "Portable Configs"
-    Relative paths in the config file are resolved relative to the config file's own directory, not the current working directory. This means configs are portable — you can run `terraflow -c /any/dir/config.yml` from any location.
+    Relative paths in the config file are resolved relative to the config file's own directory, not the current working directory. This means configs are portable — you can run `terraflow run -c /any/dir/config.yml` from any location.
 
 ## Common flags
 

--- a/docs/config/schema.md
+++ b/docs/config/schema.md
@@ -9,7 +9,7 @@ tags:
 
 # Configuration Schema
 
-TerraFlow v0.2.1 uses a single YAML configuration file that maps to the `PipelineConfig` model.
+TerraFlow uses a single YAML configuration file that maps to the `PipelineConfig` model.
 It is validated with Pydantic v2 and rejects unknown fields. Geographic coordinates are validated with custom pydantic field validators.
 
 ## Top-level fields
@@ -17,11 +17,15 @@ It is validated with Pydantic v2 and rejects unknown fields. Geographic coordina
 | Field | Type | Description |
 | --- | --- | --- |
 | `raster_path` | string | Path to the input raster (GeoTIFF). |
+| `raster_band` | integer | 1-based rasterio band index for multi-band inputs (default: `1`). Out-of-range values raise `ValueError` at start-up; the selected band is captured in `manifest.json`. |
 | `climate_csv` | string | Path to the climate CSV (must have `lat`, `lon`, and climate variable columns). |
 | `output_dir` | string | Directory to write run outputs. |
 | `roi` | object | Region of interest definition (bbox supported). |
 | `model_params` | object | Parameters for suitability scoring. |
 | `climate` | object | Climate data handling configuration (optional, defaults to spatial interpolation). |
+| `sensitivity` | object | Optional Sobol' / Morris sensitivity analysis block (consumed by `terraflow sensitivity`). |
+| `validation` | object | Optional spatial-block CV / Cohen's kappa block (consumed by `terraflow validate`). |
+| `export` | object | Optional H3 export block (consumed by `terraflow export --format h3`). |
 | `max_cells` | integer | Maximum cells sampled from the ROI (default: 500). |
 
 ## ROI (bbox)

--- a/examples/demo_config.yml
+++ b/examples/demo_config.yml
@@ -40,6 +40,7 @@ model_params:
 climate:
   strategy: spatial
   interpolation_method: kriging
+  variogram_mode: standard   # set "extended" to also evaluate nested variograms (slower)
   fallback_to_mean: true
 
 # Sensitivity analysis configuration (Phase 2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: TerraFlow
 site_description: Reproducible geospatial modeling with spatial climate interpolation — config-driven, fingerprinted, and spatially aware.
-site_url: https://gmarupilla.github.io/AgroTerraFlow/
+site_url: https://terraflow.marupilla.dev/
 repo_url: https://github.com/gmarupilla/AgroTerraFlow
 repo_name: gmarupilla/AgroTerraFlow
 edit_uri: edit/main/docs/
@@ -138,6 +138,7 @@ nav:
       - ADR-002 BBox ROI: architecture/adr-002-bbox-roi.md
       - ADR-003 Climate Interpolation: architecture/adr-003-climate-interpolation.md
       - ADR-004 CRS Reprojection: architecture/adr-004-crs-reprojection.md
+      - ADR-005 Kriging Interpolation: architecture/adr-005-kriging-interpolation.md
       - ADR-006 Homebrew Distribution: architecture/adr-006-homebrew-distribution.md
       - Boundaries: architecture/boundaries.md
       - Run Identity: architecture/run-identity.md
@@ -154,7 +155,13 @@ nav:
   - API Reference:
       - terraflow.core: api/core.md
       - terraflow.ingest: api/ingest.md
+      - terraflow.geo: api/geo.md
       - terraflow.climate: api/climate.md
+      - terraflow.model: api/model.md
+      - terraflow.stats: api/stats.md
+      - terraflow.sensitivity: api/sensitivity.md
+      - terraflow.validation: api/validation.md
+      - terraflow.export: api/export.md
   - Notebooks:
       - TerraFlow v0.2.0 Demo: notebooks/terraflow_v0_2_0_comprehensive_test.ipynb
       - Kriging and Uncertainty: notebooks/kriging_uncertainty_demo.ipynb


### PR DESCRIPTION
## Summary

Aligns docs/README/notebooks/CLAUDE.md/mkdocs.yml with the actual v0.3.0 code in `terraflow/` and the source-of-truth roadmap in `.planning/`. Corrects misleading instructions, surfaces v0.3.0 features that were undocumented, and adds API stub pages for all public modules.

### Changes
- **README.md** — quickstart fixed to `terraflow run --config` (CLI needs a subcommand; bare `--config` errors); architecture module list expanded from 9 → 15 modules; added v0.3.0 features paragraph (`raster_band`, `kriging_diagnostics`, `kriging_loocv`, `interpolation_fallback`) and link to reproducibility docs.
- **CLAUDE.md** — `Current version: 0.2.2` → `0.3.0`; added `05_extended_variogram_mode.ipynb` to the docs/notebooks listing.
- **mkdocs.yml** — `site_url` corrected to `terraflow.marupilla.dev`; added missing **ADR-005 Kriging** nav entry; API Reference nav expanded from 3 → 9 modules so all public surface area is reachable.
- **docs/config/schema.md** — documents `raster_band` top-level field plus optional `sensitivity` / `validation` / `export` blocks; dropped stale `v0.2.1` banner.
- **docs/cli/usage.md** — fixed `terraflow --config` → `terraflow run --config` in all three tabs, fixed Python API import to `run_pipeline`, added missing **H3 export** section.
- **docs/ROADMAP.md** — replaced stale 2026-02-06 Track-based content with phase-based roadmap matching `.planning/ROADMAP.md` (Phases 1–4 delivered, Phase 5 = JOSS active).
- **examples/demo_config.yml** — added `variogram_mode: standard` to surface the new 0.3.0 option.
- **docs/api/{geo,model,stats,sensitivity,validation,export}.md** — six new mkdocstrings stub pages.

## Test plan

- [x] `pytest tests/test_config.py` green (8 passed)
- [x] `terraflow.config.load_config('examples/demo_config.yml')` validates with new `variogram_mode` field
- [ ] CI mkdocs build succeeds (will run on PR)
- [ ] Verify `https://terraflow.marupilla.dev/` renders new API pages and ADR-005 after deploy