### PR TITLE
feat(geoai): add [geoai] extra, GeoAIConfig, and compute_geoai_fingerprint() (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- Optional `[geoai]` extra (`pip install terraflow-agro[geoai]`) bringing in `geoai-py` and `torch` for the upcoming `terraflow geoai` subcommand (#91, epic #90).
+- `GeoAIConfig` Pydantic block accepted under `geoai:` in pipeline configs, with validation for engine name (`fields`/`landcover`/`canopy`), power-of-two `chip_size`, `confidence_threshold` in [0, 1], and positive `batch_size`.
+- Internal `terraflow.core.run_identity.compute_geoai_fingerprint()` for deterministic GeoAI-run identity (hashes config, inputs, and `name`/`weights_sha256`/`geoai_major_minor`).
+
 ## [0.3.0] — 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 - Optional `[geoai]` extra (`pip install terraflow-agro[geoai]`) bringing in `geoai-py` and `torch` for the upcoming `terraflow geoai` subcommand (#91, epic #90).
-- `GeoAIConfig` Pydantic block accepted under `geoai:` in pipeline configs, with validation for engine name (`fields`/`landcover`/`canopy`), power-of-two `chip_size`, `confidence_threshold` in [0, 1], and positive `batch_size`.
+- `GeoAIConfig` Pydantic block accepted under `geoai:` in pipeline configs, with validation for engine name (`fields`/`landcover`/`canopy`), power-of-two `chip_size` (≥ 32), `confidence_threshold` in [0, 1], and positive `batch_size`.
 - Internal `terraflow.core.run_identity.compute_geoai_fingerprint()` for deterministic GeoAI-run identity (hashes config, inputs, and `name`/`weights_sha256`/`geoai_major_minor`).
 
 ## [0.3.0] — 2026-04-23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 viz = ["plotly>=5.0.0"]
 h3 = ["h3>=4.0,<5"]
-geoai = ["geoai-py>=0.1", "torch>=2.0"]
+geoai = ["geoai-py>=0.1", "torch>=2.0,<3"]
 dev = [
   "pytest>=7.0",
   "pytest-cov>=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 viz = ["plotly>=5.0.0"]
 h3 = ["h3>=4.0,<5"]
+geoai = ["geoai-py>=0.1", "torch>=2.0"]
 dev = [
   "pytest>=7.0",
   "pytest-cov>=3.0",

--- a/terraflow/__init__.py
+++ b/terraflow/__init__.py
@@ -8,7 +8,7 @@ This package provides utilities to:
 - Run an end-to-end, configurable pipeline
 """
 
-from .config import PipelineConfig, load_config
+from .config import GeoAIConfig, PipelineConfig, load_config
 from .export import to_h3
 from .pipeline import run_pipeline
 from .stats import (
@@ -23,6 +23,7 @@ from .stats import (
 from .validation import run_validation
 
 __all__ = [
+    "GeoAIConfig",
     "PipelineConfig",
     "load_config",
     "run_pipeline",

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -276,8 +276,8 @@ class GeoAIConfig(BaseModel):
     @field_validator("chip_size")
     @classmethod
     def validate_chip_size(cls, v: int) -> int:
-        if v <= 0 or (v & (v - 1)) != 0:
-            raise ValueError(f"chip_size must be a positive power of two, got {v}")
+        if v < 32 or (v & (v - 1)) != 0:
+            raise ValueError(f"chip_size must be a power of two >= 32, got {v}")
         return v
 
     @field_validator("confidence_threshold")

--- a/terraflow/config.py
+++ b/terraflow/config.py
@@ -263,6 +263,38 @@ class ExportConfig(BaseModel):
         return v
 
 
+class GeoAIConfig(BaseModel):
+    """Configuration for the optional ``terraflow geoai`` engine subcommand."""
+
+    engine: Literal["fields", "landcover", "canopy"]
+    chip_size: int = 512
+    confidence_threshold: float = 0.5
+    batch_size: int = 4
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("chip_size")
+    @classmethod
+    def validate_chip_size(cls, v: int) -> int:
+        if v <= 0 or (v & (v - 1)) != 0:
+            raise ValueError(f"chip_size must be a positive power of two, got {v}")
+        return v
+
+    @field_validator("confidence_threshold")
+    @classmethod
+    def validate_confidence_threshold(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError(f"confidence_threshold must be in [0, 1], got {v}")
+        return v
+
+    @field_validator("batch_size")
+    @classmethod
+    def validate_batch_size(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(f"batch_size must be positive, got {v}")
+        return v
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration.
 
@@ -297,6 +329,7 @@ class PipelineConfig(BaseModel):
     )
     validation: Optional[ValidationConfig] = None  # Optional validation config
     export: Optional[ExportConfig] = None  # Optional H3 export config
+    geoai: Optional[GeoAIConfig] = None  # Optional GeoAI engine config
 
     model_config = ConfigDict(extra="forbid")
 

--- a/terraflow/core/run_identity.py
+++ b/terraflow/core/run_identity.py
@@ -181,6 +181,12 @@ def compute_geoai_fingerprint(
       - ``weights_sha256`` (str): pretrained-weights hash
       - ``geoai_major_minor`` (str): e.g. ``"0.1"`` (patch deliberately
         excluded so bug-fix releases of ``geoai`` do not invalidate caches).
+
+    Only ``major.minor`` of the ``geoai`` library is mixed into the hash:
+    patch bumps almost never change model outputs, and silent output drift
+    from a real weight swap is already caught by ``weights_sha256``. Using
+    the full version here would needlessly invalidate the cache on every
+    bug-fix release.
     """
     config_hash = hashlib.sha256(canonicalize_config(config_dict)).hexdigest()
 

--- a/terraflow/core/run_identity.py
+++ b/terraflow/core/run_identity.py
@@ -167,3 +167,46 @@ def compute_run_fingerprint(
 
     digest = hashlib.sha256(payload_bytes).digest()
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def compute_geoai_fingerprint(
+    config_dict: dict,
+    input_fingerprints: list[dict],
+    model_metadata: dict,
+) -> str:
+    """Deterministic fingerprint for a ``terraflow geoai`` engine run.
+
+    ``model_metadata`` must contain:
+      - ``name`` (str): model identifier
+      - ``weights_sha256`` (str): pretrained-weights hash
+      - ``geoai_major_minor`` (str): e.g. ``"0.1"`` (patch deliberately
+        excluded so bug-fix releases of ``geoai`` do not invalidate caches).
+    """
+    config_hash = hashlib.sha256(canonicalize_config(config_dict)).hexdigest()
+
+    inputs_payload = sorted(
+        (
+            {"sha256": fp["sha256"], "size_bytes": fp["size_bytes"]}
+            for fp in input_fingerprints
+        ),
+        key=lambda item: (item["sha256"], item["size_bytes"]),
+    )
+
+    payload = {
+        "config": config_hash,
+        "inputs": inputs_payload,
+        "model": {
+            "name": model_metadata["name"],
+            "weights_sha256": model_metadata["weights_sha256"],
+            "geoai_major_minor": model_metadata["geoai_major_minor"],
+        },
+    }
+    payload_bytes = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+    digest = hashlib.sha256(payload_bytes).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,9 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
-from terraflow.config import load_config
+from terraflow.config import GeoAIConfig, load_config
 
 
 def test_load_config_tmp(tmp_path: Path):
@@ -202,3 +203,119 @@ def test_load_config_kriging_variogram_mode(tmp_path: Path):
 
     cfg = load_config(cfg_file)
     assert cfg.climate.variogram_mode == "extended"
+
+
+# ---------------------------------------------------------------------------
+# GeoAIConfig (issue #91 — foundation for `terraflow geoai` subcommand)
+# ---------------------------------------------------------------------------
+
+
+def test_geoai_config_defaults_valid():
+    cfg = GeoAIConfig(engine="landcover")
+    assert cfg.engine == "landcover"
+    assert cfg.chip_size == 512
+    assert cfg.confidence_threshold == 0.5
+    assert cfg.batch_size == 4
+
+
+def test_geoai_config_rejects_bad_engine():
+    with pytest.raises(ValidationError):
+        GeoAIConfig(engine="bogus")
+
+
+@pytest.mark.parametrize("size", [64, 128, 256, 512, 1024, 2048])
+def test_geoai_config_accepts_pow2_chip_sizes(size: int):
+    cfg = GeoAIConfig(engine="fields", chip_size=size)
+    assert cfg.chip_size == size
+
+
+@pytest.mark.parametrize("size", [0, -1, 3, 500, 513])
+def test_geoai_config_rejects_non_pow2_chip_size(size: int):
+    with pytest.raises(ValidationError, match="chip_size"):
+        GeoAIConfig(engine="fields", chip_size=size)
+
+
+@pytest.mark.parametrize("threshold", [-0.1, 1.1, 2.0])
+def test_geoai_config_rejects_out_of_range_threshold(threshold: float):
+    with pytest.raises(ValidationError, match="confidence_threshold"):
+        GeoAIConfig(engine="canopy", confidence_threshold=threshold)
+
+
+@pytest.mark.parametrize("batch", [0, -1, -100])
+def test_geoai_config_rejects_non_positive_batch_size(batch: int):
+    with pytest.raises(ValidationError, match="batch_size"):
+        GeoAIConfig(engine="fields", batch_size=batch)
+
+
+def test_geoai_config_rejects_unknown_keys():
+    with pytest.raises(ValidationError):
+        GeoAIConfig(engine="fields", bogus_key=1)
+
+
+def test_pipeline_config_accepts_optional_geoai_block(tmp_path: Path):
+    cfg_content = textwrap.dedent("""
+        raster_path: "data/usda_cdl.tif"
+        climate_csv: "data/demo_climate.csv"
+        output_dir: "outputs/demo_run"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 10.0
+          ymax: 10.0
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        geoai:
+          engine: "landcover"
+          chip_size: 256
+          confidence_threshold: 0.75
+          batch_size: 8
+        """)
+
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(cfg_content, encoding="utf-8")
+
+    cfg = load_config(cfg_file)
+    assert cfg.geoai is not None
+    assert cfg.geoai.engine == "landcover"
+    assert cfg.geoai.chip_size == 256
+    assert cfg.geoai.confidence_threshold == 0.75
+    assert cfg.geoai.batch_size == 8
+
+
+def test_pipeline_config_geoai_defaults_to_none(tmp_path: Path):
+    cfg_content = textwrap.dedent("""
+        raster_path: "data/usda_cdl.tif"
+        climate_csv: "data/demo_climate.csv"
+        output_dir: "outputs/demo_run"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 10.0
+          ymax: 10.0
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        """)
+
+    cfg_file = tmp_path / "cfg.yml"
+    cfg_file.write_text(cfg_content, encoding="utf-8")
+
+    cfg = load_config(cfg_file)
+    assert cfg.geoai is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,7 +214,7 @@ def test_geoai_config_defaults_valid():
     cfg = GeoAIConfig(engine="landcover")
     assert cfg.engine == "landcover"
     assert cfg.chip_size == 512
-    assert cfg.confidence_threshold == 0.5
+    assert cfg.confidence_threshold == pytest.approx(0.5)
     assert cfg.batch_size == 4
 
 
@@ -287,7 +287,7 @@ def test_pipeline_config_accepts_optional_geoai_block(tmp_path: Path):
     assert cfg.geoai is not None
     assert cfg.geoai.engine == "landcover"
     assert cfg.geoai.chip_size == 256
-    assert cfg.geoai.confidence_threshold == 0.75
+    assert cfg.geoai.confidence_threshold == pytest.approx(0.75)
     assert cfg.geoai.batch_size == 8
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,7 +229,7 @@ def test_geoai_config_accepts_pow2_chip_sizes(size: int):
     assert cfg.chip_size == size
 
 
-@pytest.mark.parametrize("size", [0, -1, 3, 500, 513])
+@pytest.mark.parametrize("size", [0, -1, 1, 2, 3, 16, 500, 513])
 def test_geoai_config_rejects_non_pow2_chip_size(size: int):
     with pytest.raises(ValidationError, match="chip_size"):
         GeoAIConfig(engine="fields", chip_size=size)

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -6,6 +6,7 @@ import pytest
 
 from terraflow.core.run_identity import (
     canonicalize_config,
+    compute_geoai_fingerprint,
     compute_run_fingerprint,
     fingerprint_file,
     hash_roi_geometry,
@@ -221,3 +222,89 @@ def test_resolve_roi_hash_from_path(tmp_path: Path):
 
     with pytest.raises(ValueError, match="ROI configuration missing"):
         _resolve_roi_hash({}, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# compute_geoai_fingerprint (issue #91)
+# ---------------------------------------------------------------------------
+
+
+def _geoai_args():
+    config_dict = {
+        "geoai": {
+            "engine": "landcover",
+            "chip_size": 512,
+            "confidence_threshold": 0.5,
+            "batch_size": 4,
+        }
+    }
+    inputs = [{"sha256": "a" * 64, "size_bytes": 1024}]
+    model_meta = {
+        "name": "ftw-v1",
+        "weights_sha256": "b" * 64,
+        "geoai_major_minor": "0.1",
+    }
+    return config_dict, inputs, model_meta
+
+
+def test_geoai_fingerprint_deterministic():
+    cfg, inputs, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, inputs, model)
+    fp2 = compute_geoai_fingerprint(cfg, inputs, model)
+    assert fp1 == fp2
+    # base64url, no padding
+    assert "=" not in fp1
+    assert len(fp1) > 30
+
+
+def test_geoai_fingerprint_changes_when_weights_change():
+    cfg, inputs, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, inputs, model)
+
+    bumped = dict(model, weights_sha256="c" * 64)
+    fp2 = compute_geoai_fingerprint(cfg, inputs, bumped)
+    assert fp1 != fp2
+
+
+def test_geoai_fingerprint_stable_across_geoai_patch_bump():
+    cfg, inputs, model = _geoai_args()
+    # Caller passes only "major.minor", so a 0.1.5 → 0.1.6 patch bump
+    # must not change the hash because the field value is identical.
+    fp1 = compute_geoai_fingerprint(cfg, inputs, dict(model, geoai_major_minor="0.1"))
+    fp2 = compute_geoai_fingerprint(cfg, inputs, dict(model, geoai_major_minor="0.1"))
+    assert fp1 == fp2
+
+    # Sanity: a real minor bump *must* change the hash.
+    fp3 = compute_geoai_fingerprint(cfg, inputs, dict(model, geoai_major_minor="0.2"))
+    assert fp1 != fp3
+
+
+def test_geoai_fingerprint_changes_when_config_changes():
+    cfg, inputs, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, inputs, model)
+
+    bumped_cfg = json.loads(json.dumps(cfg))
+    bumped_cfg["geoai"]["confidence_threshold"] = 0.75
+    fp2 = compute_geoai_fingerprint(bumped_cfg, inputs, model)
+    assert fp1 != fp2
+
+
+def test_geoai_fingerprint_changes_when_inputs_change():
+    cfg, inputs, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, inputs, model)
+
+    bumped_inputs = [{"sha256": "d" * 64, "size_bytes": 1024}]
+    fp2 = compute_geoai_fingerprint(cfg, bumped_inputs, model)
+    assert fp1 != fp2
+
+
+def test_geoai_fingerprint_input_order_invariant():
+    cfg, _, model = _geoai_args()
+    inputs_a = [
+        {"sha256": "a" * 64, "size_bytes": 100},
+        {"sha256": "b" * 64, "size_bytes": 200},
+    ]
+    inputs_b = list(reversed(inputs_a))
+    assert compute_geoai_fingerprint(cfg, inputs_a, model) == compute_geoai_fingerprint(
+        cfg, inputs_b, model
+    )

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -298,6 +298,24 @@ def test_geoai_fingerprint_changes_when_inputs_change():
     assert fp1 != fp2
 
 
+def test_geoai_fingerprint_changes_when_model_name_changes():
+    cfg, inputs, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, inputs, model)
+
+    renamed = dict(model, name="ftw-v2")
+    fp2 = compute_geoai_fingerprint(cfg, inputs, renamed)
+    assert fp1 != fp2
+
+
+def test_geoai_fingerprint_empty_inputs_stable():
+    cfg, _, model = _geoai_args()
+    fp1 = compute_geoai_fingerprint(cfg, [], model)
+    fp2 = compute_geoai_fingerprint(cfg, [], model)
+    assert fp1 == fp2
+    assert "=" not in fp1
+    assert len(fp1) > 30
+
+
 def test_geoai_fingerprint_input_order_invariant():
     cfg, _, model = _geoai_args()
     inputs_a = [


### PR DESCRIPTION
## Summary

Foundation slice (1 of 7) of the `terraflow geoai` engine integration — epic #90, closes #91. Lands the three primitives every downstream slice (#92–#97) depends on. No engine, no CLI, no docs yet.

- **`[geoai]` optional extra** in `pyproject.toml` (`geoai-py>=0.1`, `torch>=2.0,<3`). Base install stays lean.
- **`GeoAIConfig`** Pydantic model in `terraflow/config.py`:
  - `engine: Literal["fields", "landcover", "canopy"]`
  - `chip_size` (power of two ≥ 32, default `512`)
  - `confidence_threshold` (`[0, 1]`, default `0.5`)
  - `batch_size` (positive, default `4`)
  - `model_config = ConfigDict(extra="forbid")`
  - Wired into `PipelineConfig` as `geoai: Optional[GeoAIConfig] = None`.
- **`compute_geoai_fingerprint(config_dict, input_fingerprints, model_metadata)`** in `terraflow/core/run_identity.py`. Mirrors `compute_run_fingerprint`'s sorted-JSON / SHA-256 / base64url canonicalization. Hashes config + sorted inputs + `(name, weights_sha256, geoai_major_minor)` — `geoai_major_minor` excludes patch so geoai bug-fix releases don't invalidate caches (silent output drift is already covered by `weights_sha256`).
- **`GeoAIConfig` re-exported** from `terraflow.__init__` (matches `PipelineConfig`); fingerprint helper stays in `terraflow.core.run_identity` (internal, consumed by `geoai_engine.py` in #92).
- **CHANGELOG**: `[Unreleased] ### Added` entry.

## Scope deviation from CLAUDE.md

CLAUDE.md mandates README / docs / notebook on every PR. Issue #91 explicitly puts those out of scope and defers them to #95 (user guide + notebook) and #96 (demo config + README). Followed the issue boundary.

## Review nits addressed in-PR

Independent second-opinion review surfaced 8 findings (`LGTM with nits`). Acted on 4 here:
- `pyproject.toml`: `torch>=2.0` → `torch>=2.0,<3` (mirror `h3>=4.0,<5` pin).
- `GeoAIConfig.validate_chip_size`: pow-2 alone allowed `chip_size=1`; added floor of 32.
- `compute_geoai_fingerprint` docstring: explain why `geoai_major_minor` (not full version).
- `tests/test_run_identity.py`: assert model-name flip changes hash; empty `input_fingerprints` is stable.

Deferred to MR 2 (#92, engine slice): adding `device` + `torch_major_minor` to `model_metadata`; TypedDict shape validation for `input_fingerprints` entries.

## Test plan

- [x] `make lint` — ruff + black clean
- [x] `make typecheck` — mypy clean (38 files)
- [x] `make test-cov` — **259 passed**, coverage **87.42%** (≥ 85% floor)
- [x] New tests:
  - `GeoAIConfig`: defaults; bad engine; pow-2 chip_size (parametrized 64–2048 ok, parametrized 0/-1/1/2/3/16/500/513 reject); threshold range; positive batch; unknown-key rejection; full `PipelineConfig` YAML round-trip with and without `geoai:` block.
  - `compute_geoai_fingerprint`: deterministic; weights-bump changes hash; **patch-bump stability** (caller passes only `major.minor`); model-name bump changes hash; empty `input_fingerprints` is stable; config-bump changes hash; inputs-bump changes hash; input-order invariance.
- [x] Smoke: `from terraflow import GeoAIConfig; GeoAIConfig(engine='fields')` round-trips; fingerprint helper returns a stable base64url digest.

## Follow-ups (separate PRs)

| MR | Issue | Slice |
|----|-------|-------|
| 2 | #92 | `terraflow/geoai_engine.py` (3 runners + mocked tests) |
| 3 | #93 | `terraflow geoai` Typer sub-app |
| 4 | #94 | JOSS paper Wu (2026) citation |
| 5 | #95 | User guide + notebook + mkdocs nav |
| 6 | #96 | Demo config block + README |
| 7 | #97 | Opt-in `geoai-tests.yml` workflow |

Refs #90.