### PR TITLE
feat(geoai): geoai_engine module with fields/landcover/canopy runners (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Added
 - Optional `[geoai]` extra (`pip install terraflow-agro[geoai]`) bringing in `geoai-py` and `torch` for the upcoming `terraflow geoai` subcommand (#91, epic #90).
 - `GeoAIConfig` Pydantic block accepted under `geoai:` in pipeline configs, with validation for engine name (`fields`/`landcover`/`canopy`), power-of-two `chip_size` (≥ 32), `confidence_threshold` in [0, 1], and positive `batch_size`.
-- Internal `terraflow.core.run_identity.compute_geoai_fingerprint()` for deterministic GeoAI-run identity (hashes config, inputs, and `name`/`weights_sha256`/`geoai_major_minor`).
+- Internal `terraflow.core.run_identity.compute_geoai_fingerprint()` for deterministic GeoAI-run identity. Hashes config, inputs (`{sha256, size_bytes}` shape now enforced), and `name`/`weights_sha256`/`geoai_major_minor`; optionally also `device` and `torch_major_minor`.
+- `terraflow.geoai_engine` module with `run_fields()`, `run_landcover()`, `run_canopy()` orchestrators (#92). Validates `config.geoai.engine`, fingerprints inputs + device/torch, writes artifacts to `<output_dir>/runs/<geoai_fingerprint>/geoai/`, emits `geoai_manifest.json` and `report.json`, seeds `torch.manual_seed` from the fingerprint, and skips inference on cache hits. Engine bodies are placeholders that land in #94.
 
 ## [0.3.0] — 2026-04-23
 

--- a/terraflow/core/run_identity.py
+++ b/terraflow/core/run_identity.py
@@ -169,6 +169,13 @@ def compute_run_fingerprint(
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
 
+_GEOAI_REQUIRED_MODEL_KEYS = frozenset(
+    {"name", "weights_sha256", "geoai_major_minor"}
+)
+_GEOAI_OPTIONAL_MODEL_KEYS = frozenset({"device", "torch_major_minor"})
+_GEOAI_INPUT_KEYS = frozenset({"sha256", "size_bytes"})
+
+
 def compute_geoai_fingerprint(
     config_dict: dict,
     input_fingerprints: list[dict],
@@ -182,12 +189,43 @@ def compute_geoai_fingerprint(
       - ``geoai_major_minor`` (str): e.g. ``"0.1"`` (patch deliberately
         excluded so bug-fix releases of ``geoai`` do not invalidate caches).
 
+    And may optionally contain:
+      - ``device`` (str): ``"cpu"`` / ``"cuda"`` / ``"mps"`` — different devices
+        yield different floating-point and cuDNN-kernel results.
+      - ``torch_major_minor`` (str): e.g. ``"2.3"`` — minor torch bumps can
+        shift kernel implementations.
+
     Only ``major.minor`` of the ``geoai`` library is mixed into the hash:
     patch bumps almost never change model outputs, and silent output drift
     from a real weight swap is already caught by ``weights_sha256``. Using
     the full version here would needlessly invalidate the cache on every
     bug-fix release.
+
+    ``input_fingerprints`` entries must be dicts with exactly the keys
+    ``sha256`` and ``size_bytes``; extra or missing keys raise ``ValueError``.
     """
+    missing_model = _GEOAI_REQUIRED_MODEL_KEYS - model_metadata.keys()
+    if missing_model:
+        raise ValueError(
+            f"model_metadata missing required keys: {sorted(missing_model)}"
+        )
+    unknown_model = (
+        model_metadata.keys()
+        - _GEOAI_REQUIRED_MODEL_KEYS
+        - _GEOAI_OPTIONAL_MODEL_KEYS
+    )
+    if unknown_model:
+        raise ValueError(
+            f"model_metadata has unexpected keys: {sorted(unknown_model)}"
+        )
+
+    for idx, fp in enumerate(input_fingerprints):
+        if set(fp.keys()) != _GEOAI_INPUT_KEYS:
+            raise ValueError(
+                f"input_fingerprints[{idx}] must have exactly keys "
+                f"{sorted(_GEOAI_INPUT_KEYS)}, got {sorted(fp.keys())}"
+            )
+
     config_hash = hashlib.sha256(canonicalize_config(config_dict)).hexdigest()
 
     inputs_payload = sorted(
@@ -198,14 +236,19 @@ def compute_geoai_fingerprint(
         key=lambda item: (item["sha256"], item["size_bytes"]),
     )
 
+    model_payload = {
+        "name": model_metadata["name"],
+        "weights_sha256": model_metadata["weights_sha256"],
+        "geoai_major_minor": model_metadata["geoai_major_minor"],
+    }
+    for opt_key in _GEOAI_OPTIONAL_MODEL_KEYS:
+        if opt_key in model_metadata:
+            model_payload[opt_key] = model_metadata[opt_key]
+
     payload = {
         "config": config_hash,
         "inputs": inputs_payload,
-        "model": {
-            "name": model_metadata["name"],
-            "weights_sha256": model_metadata["weights_sha256"],
-            "geoai_major_minor": model_metadata["geoai_major_minor"],
-        },
+        "model": model_payload,
     }
     payload_bytes = json.dumps(
         payload,

--- a/terraflow/geoai_engine.py
+++ b/terraflow/geoai_engine.py
@@ -1,0 +1,245 @@
+"""GeoAI engine adapter — wraps `geoai-py` for fields/landcover/canopy inference.
+
+Each public runner (`run_fields`, `run_landcover`, `run_canopy`):
+- Requires the optional `[geoai]` extra (`geoai-py`, `torch`).
+- Validates that ``config.geoai.engine`` matches the runner.
+- Computes a deterministic ``geoai_fingerprint`` over config + raster hash + model
+  metadata (incl. device + torch version, so identical inputs on different
+  devices map to different cache directories).
+- Writes artifacts to ``<output_dir>/runs/<geoai_fingerprint>/geoai/``.
+- Always writes ``geoai_manifest.json`` + ``report.json``.
+- Seeds ``torch.manual_seed`` from the fingerprint for reproducibility.
+- Skips inference on a cache hit (manifest already present).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Callable, Dict
+
+try:
+    import geoai
+    import torch
+
+    _GEOAI_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised via patch in tests
+    geoai = None
+    torch = None
+    _GEOAI_AVAILABLE = False
+
+from .config import PipelineConfig, build_config, load_config_dict
+from .core.run_identity import compute_geoai_fingerprint, fingerprint_file
+from .pipeline import _atomic_write_text
+from .utils import logger
+
+_INSTALL_HINT = (
+    "geoai-py and torch are required for the `terraflow geoai` engine. "
+    "Install with: pip install terraflow-agro[geoai]"
+)
+
+# Pretrained-weight identifiers per engine. SHA values are placeholders pinned
+# to the geoai-py bundled checkpoints; #94 wires in real digests.
+_MODEL_NAME: Dict[str, str] = {
+    "fields": "ftw-v1",
+    "landcover": "landcover-v1",
+    "canopy": "canopy-v1",
+}
+_WEIGHTS_SHA: Dict[str, str] = {
+    "fields": "0" * 64,
+    "landcover": "0" * 64,
+    "canopy": "0" * 64,
+}
+
+
+def _require_geoai() -> None:
+    if not _GEOAI_AVAILABLE:
+        raise ImportError(_INSTALL_HINT)
+
+
+def _device() -> str:
+    if not _GEOAI_AVAILABLE:
+        return "cpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    mps = getattr(torch.backends, "mps", None)
+    if mps is not None and mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _major_minor(version: str) -> str:
+    parts = version.split(".")
+    if len(parts) >= 2:
+        return f"{parts[0]}.{parts[1]}"
+    return parts[0] if parts else "0"
+
+
+def _torch_major_minor() -> str:
+    if not _GEOAI_AVAILABLE:
+        return "0.0"
+    return _major_minor(getattr(torch, "__version__", "0.0"))
+
+
+def _geoai_major_minor() -> str:
+    if not _GEOAI_AVAILABLE:
+        return "0.0"
+    return _major_minor(getattr(geoai, "__version__", "0.0"))
+
+
+def _seed_torch(fingerprint: str) -> None:
+    if not _GEOAI_AVAILABLE:
+        return
+    seed = int.from_bytes(fingerprint[:8].encode("ascii"), "big") % (2**31)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _model_metadata(engine: str) -> Dict[str, str]:
+    return {
+        "name": _MODEL_NAME[engine],
+        "weights_sha256": _WEIGHTS_SHA[engine],
+        "geoai_major_minor": _geoai_major_minor(),
+        "device": _device(),
+        "torch_major_minor": _torch_major_minor(),
+    }
+
+
+def _resolve_input_paths(config_path: Path, config_dict: dict) -> None:
+    """Resolve relative raster_path / output_dir against config dir (in place)."""
+    config_dir = config_path.resolve().parent
+    for key in ("raster_path", "output_dir"):
+        raw = config_dict.get(key)
+        if raw is None:
+            continue
+        p = Path(str(raw))
+        if not p.is_absolute():
+            config_dict[key] = str((config_dir / p).resolve())
+
+
+def _run(
+    engine: str,
+    runner_fn: Callable[[PipelineConfig, Path], None],
+    config_path: Path | str,
+) -> Path:
+    _require_geoai()
+
+    config_path = Path(config_path)
+    config_dict = load_config_dict(config_path)
+    _resolve_input_paths(config_path, config_dict)
+    cfg = build_config(config_dict)
+
+    if cfg.geoai is None:
+        raise ValueError(
+            "Config has no `geoai:` block — required for the geoai engine."
+        )
+    if cfg.geoai.engine != engine:
+        raise ValueError(
+            f"Config `geoai.engine={cfg.geoai.engine!r}` does not match "
+            f"runner `{engine!r}`."
+        )
+
+    raster_fp = fingerprint_file(str(cfg.raster_path))
+    input_fingerprints = [
+        {"sha256": raster_fp["sha256"], "size_bytes": raster_fp["size_bytes"]}
+    ]
+    model_meta = _model_metadata(engine)
+
+    fingerprint = compute_geoai_fingerprint(
+        config_dict, input_fingerprints, model_meta
+    )
+    run_dir = Path(cfg.output_dir) / "runs" / fingerprint / "geoai"
+    manifest_path = run_dir / "geoai_manifest.json"
+
+    if manifest_path.exists():
+        logger.info(f"geoai cache hit — {run_dir}")
+        return run_dir
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _seed_torch(fingerprint)
+
+    start = time.perf_counter()
+    runner_fn(cfg, run_dir)
+    elapsed = time.perf_counter() - start
+
+    _atomic_write_text(
+        manifest_path,
+        json.dumps(
+            {
+                "engine": engine,
+                "geoai_fingerprint": fingerprint,
+                "model": model_meta,
+                "inputs": input_fingerprints,
+                "config": config_dict,
+            },
+            sort_keys=True,
+            indent=2,
+            default=str,
+        ),
+    )
+    _atomic_write_text(
+        run_dir / "report.json",
+        json.dumps(
+            {
+                "engine": engine,
+                "duration_s": round(elapsed, 6),
+                "device": model_meta["device"],
+                "torch_major_minor": model_meta["torch_major_minor"],
+                "deterministic": True,
+            },
+            sort_keys=True,
+            indent=2,
+        ),
+    )
+
+    return run_dir
+
+
+# ---------------------------------------------------------------------------
+# Engine-specific runner bodies. Each writes its declared artifact set into
+# *run_dir*. Real geoai-py calls land in #94 — for now bodies are minimal
+# placeholders that tests monkey-patch.
+# ---------------------------------------------------------------------------
+
+
+def _do_fields(cfg: PipelineConfig, run_dir: Path) -> None:  # pragma: no cover
+    _require_geoai()
+    raise NotImplementedError("geoai.ftw integration lands in #94")
+
+
+def _do_landcover(
+    cfg: PipelineConfig, run_dir: Path
+) -> None:  # pragma: no cover
+    _require_geoai()
+    raise NotImplementedError("geoai.classify integration lands in #94")
+
+
+def _do_canopy(cfg: PipelineConfig, run_dir: Path) -> None:  # pragma: no cover
+    _require_geoai()
+    raise NotImplementedError("geoai.canopy integration lands in #94")
+
+
+def run_fields(config_path: Path | str) -> Path:
+    """Run field-boundary detection. Returns the run directory."""
+    return _run("fields", _do_fields, config_path)
+
+
+def run_landcover(config_path: Path | str) -> Path:
+    """Run landcover classification. Returns the run directory."""
+    return _run("landcover", _do_landcover, config_path)
+
+
+def run_canopy(config_path: Path | str) -> Path:
+    """Run canopy-height regression. Returns the run directory."""
+    return _run("canopy", _do_canopy, config_path)
+
+
+__all__ = [
+    "run_fields",
+    "run_landcover",
+    "run_canopy",
+    "_require_geoai",
+    "_GEOAI_AVAILABLE",
+]

--- a/tests/test_geoai_engine.py
+++ b/tests/test_geoai_engine.py
@@ -1,0 +1,266 @@
+"""Mocked-engine tests for ``terraflow.geoai_engine`` (issue #92).
+
+The optional ``[geoai]`` extra is *not* installed in baseline CI, so every test
+patches ``_GEOAI_AVAILABLE`` to True and replaces the torch / geoai-touching
+helpers with no-ops. Engine bodies are monkey-patched to write the documented
+artifact set; this lets us cover orchestration (config validation, fingerprinting,
+caching, manifest/report) without any heavy ML deps.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from terraflow import geoai_engine
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_config(
+    tmp_path: Path,
+    raster_path: Path,
+    engine: str,
+    confidence_threshold: float = 0.5,
+    filename: str | None = None,
+) -> Path:
+    cfg = textwrap.dedent(
+        f"""
+        raster_path: "{raster_path}"
+        climate_csv: "{tmp_path / 'climate.csv'}"
+        output_dir: "{tmp_path / 'outputs'}"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 1.0
+          ymax: 1.0
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        geoai:
+          engine: "{engine}"
+          chip_size: 64
+          confidence_threshold: {confidence_threshold}
+          batch_size: 2
+        """
+    )
+    cfg_path = tmp_path / (filename or f"cfg_{engine}.yml")
+    cfg_path.write_text(cfg, encoding="utf-8")
+    return cfg_path
+
+
+@pytest.fixture
+def stub_geoai(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend the [geoai] extra is installed; no-op torch helpers."""
+    monkeypatch.setattr(geoai_engine, "_GEOAI_AVAILABLE", True)
+    monkeypatch.setattr(geoai_engine, "_seed_torch", lambda fp: None)
+    monkeypatch.setattr(geoai_engine, "_device", lambda: "cpu")
+    monkeypatch.setattr(geoai_engine, "_torch_major_minor", lambda: "2.0")
+    monkeypatch.setattr(geoai_engine, "_geoai_major_minor", lambda: "0.1")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_require_geoai_raises_with_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(geoai_engine, "_GEOAI_AVAILABLE", False)
+    with pytest.raises(ImportError, match=r"pip install terraflow-agro\[geoai\]"):
+        geoai_engine._require_geoai()
+
+
+def test_helpers_short_circuit_without_geoai(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the [geoai] extra installed, helpers return safe defaults."""
+    monkeypatch.setattr(geoai_engine, "_GEOAI_AVAILABLE", False)
+    assert geoai_engine._device() == "cpu"
+    assert geoai_engine._torch_major_minor() == "0.0"
+    assert geoai_engine._geoai_major_minor() == "0.0"
+    geoai_engine._seed_torch("abcd1234")  # no-op, must not raise
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [("2.3.1", "2.3"), ("0.1", "0.1"), ("3", "3")],
+)
+def test_major_minor_helper(version: str, expected: str) -> None:
+    assert geoai_engine._major_minor(version) == expected
+
+
+def test_runner_rejects_wrong_engine_in_config(
+    tmp_path: Path, synthetic_raster: Path, stub_geoai: None
+) -> None:
+    cfg_path = _write_config(tmp_path, synthetic_raster, engine="landcover")
+    with pytest.raises(ValueError, match="does not match"):
+        geoai_engine.run_fields(cfg_path)
+
+
+def test_runner_rejects_missing_geoai_block(
+    tmp_path: Path, synthetic_raster: Path, stub_geoai: None
+) -> None:
+    cfg = textwrap.dedent(
+        f"""
+        raster_path: "{synthetic_raster}"
+        climate_csv: "{tmp_path / 'climate.csv'}"
+        output_dir: "{tmp_path / 'outputs'}"
+        roi:
+          type: "bbox"
+          xmin: 0.0
+          ymin: 0.0
+          xmax: 1.0
+          ymax: 1.0
+        model_params:
+          v_min: 0.0
+          v_max: 1.0
+          t_min: 0.0
+          t_max: 40.0
+          r_min: 0.0
+          r_max: 300.0
+          w_v: 0.4
+          w_t: 0.3
+          w_r: 0.3
+        """
+    )
+    cfg_path = tmp_path / "cfg_no_geoai.yml"
+    cfg_path.write_text(cfg, encoding="utf-8")
+    with pytest.raises(ValueError, match="no `geoai:` block"):
+        geoai_engine.run_fields(cfg_path)
+
+
+def _stub_runner_factory(artifacts: Tuple[str, ...]):
+    """Return a runner body that writes empty placeholder files."""
+    calls: list[Path] = []
+
+    def _stub(_cfg, run_dir: Path) -> None:
+        calls.append(run_dir)
+        for name in artifacts:
+            (run_dir / name).write_text("", encoding="utf-8")
+
+    _stub.calls = calls  # type: ignore[attr-defined]
+    return _stub
+
+
+@pytest.mark.parametrize(
+    "engine, runner_attr, public_fn, artifacts",
+    [
+        (
+            "fields",
+            "_do_fields",
+            "run_fields",
+            ("fields.geojson", "field_stats.parquet"),
+        ),
+        (
+            "landcover",
+            "_do_landcover",
+            "run_landcover",
+            ("landcover.tif", "landcover_proba.tif", "class_fractions.json"),
+        ),
+        (
+            "canopy",
+            "_do_canopy",
+            "run_canopy",
+            ("canopy_height.tif", "canopy_stats.json"),
+        ),
+    ],
+)
+def test_runner_writes_artifacts(
+    tmp_path: Path,
+    synthetic_raster: Path,
+    stub_geoai: None,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+    runner_attr: str,
+    public_fn: str,
+    artifacts: Tuple[str, ...],
+) -> None:
+    stub = _stub_runner_factory(artifacts)
+    monkeypatch.setattr(geoai_engine, runner_attr, stub)
+
+    cfg_path = _write_config(tmp_path, synthetic_raster, engine=engine)
+    run_dir = getattr(geoai_engine, public_fn)(cfg_path)
+
+    assert run_dir.parent.parent == tmp_path / "outputs" / "runs"
+    for name in artifacts:
+        assert (run_dir / name).exists(), f"missing artifact {name}"
+
+    manifest = json.loads((run_dir / "geoai_manifest.json").read_text())
+    assert manifest["engine"] == engine
+    assert manifest["model"]["device"] == "cpu"
+    assert manifest["model"]["torch_major_minor"] == "2.0"
+    assert manifest["model"]["geoai_major_minor"] == "0.1"
+    assert len(manifest["inputs"]) == 1
+    assert set(manifest["inputs"][0].keys()) == {"sha256", "size_bytes"}
+
+    report = json.loads((run_dir / "report.json").read_text())
+    assert report["engine"] == engine
+    assert report["device"] == "cpu"
+    assert report["deterministic"] is True
+    assert "duration_s" in report
+
+    assert len(stub.calls) == 1  # type: ignore[attr-defined]
+
+
+def test_runner_cache_hit_skips_inference(
+    tmp_path: Path,
+    synthetic_raster: Path,
+    stub_geoai: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _stub_runner_factory(("fields.geojson", "field_stats.parquet"))
+    monkeypatch.setattr(geoai_engine, "_do_fields", stub)
+
+    cfg_path = _write_config(tmp_path, synthetic_raster, engine="fields")
+    first = geoai_engine.run_fields(cfg_path)
+    second = geoai_engine.run_fields(cfg_path)
+
+    assert first == second
+    assert len(stub.calls) == 1  # type: ignore[attr-defined]
+
+
+def test_threshold_bump_produces_new_fingerprint(
+    tmp_path: Path,
+    synthetic_raster: Path,
+    stub_geoai: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _stub_runner_factory(("fields.geojson", "field_stats.parquet"))
+    monkeypatch.setattr(geoai_engine, "_do_fields", stub)
+
+    cfg_a = _write_config(
+        tmp_path,
+        synthetic_raster,
+        engine="fields",
+        confidence_threshold=0.5,
+        filename="cfg_a.yml",
+    )
+    cfg_b = _write_config(
+        tmp_path,
+        synthetic_raster,
+        engine="fields",
+        confidence_threshold=0.9,
+        filename="cfg_b.yml",
+    )
+
+    dir_a = geoai_engine.run_fields(cfg_a)
+    dir_b = geoai_engine.run_fields(cfg_b)
+
+    assert dir_a != dir_b
+    assert len(stub.calls) == 2  # type: ignore[attr-defined]

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -326,3 +326,49 @@ def test_geoai_fingerprint_input_order_invariant():
     assert compute_geoai_fingerprint(cfg, inputs_a, model) == compute_geoai_fingerprint(
         cfg, inputs_b, model
     )
+
+
+def test_geoai_fingerprint_changes_when_device_changes():
+    cfg, inputs, model = _geoai_args()
+    cpu_model = dict(model, device="cpu", torch_major_minor="2.3")
+    cuda_model = dict(model, device="cuda", torch_major_minor="2.3")
+    fp_cpu = compute_geoai_fingerprint(cfg, inputs, cpu_model)
+    fp_cuda = compute_geoai_fingerprint(cfg, inputs, cuda_model)
+    assert fp_cpu != fp_cuda
+
+
+def test_geoai_fingerprint_changes_when_torch_minor_changes():
+    cfg, inputs, model = _geoai_args()
+    a = dict(model, device="cpu", torch_major_minor="2.3")
+    b = dict(model, device="cpu", torch_major_minor="2.4")
+    assert compute_geoai_fingerprint(cfg, inputs, a) != compute_geoai_fingerprint(
+        cfg, inputs, b
+    )
+
+
+def test_geoai_fingerprint_rejects_missing_required_model_key():
+    cfg, inputs, _ = _geoai_args()
+    bad = {"name": "ftw-v1", "weights_sha256": "b" * 64}  # missing geoai_major_minor
+    with pytest.raises(ValueError, match="missing required keys"):
+        compute_geoai_fingerprint(cfg, inputs, bad)
+
+
+def test_geoai_fingerprint_rejects_unknown_model_key():
+    cfg, inputs, model = _geoai_args()
+    bad = dict(model, foo="bar")
+    with pytest.raises(ValueError, match="unexpected keys"):
+        compute_geoai_fingerprint(cfg, inputs, bad)
+
+
+def test_geoai_fingerprint_rejects_malformed_input_entry():
+    cfg, _, model = _geoai_args()
+    # Missing size_bytes
+    with pytest.raises(ValueError, match=r"input_fingerprints\[0\]"):
+        compute_geoai_fingerprint(cfg, [{"sha256": "a" * 64}], model)
+    # Extra key
+    with pytest.raises(ValueError, match=r"input_fingerprints\[0\]"):
+        compute_geoai_fingerprint(
+            cfg,
+            [{"sha256": "a" * 64, "size_bytes": 100, "path": "/tmp/x"}],
+            model,
+        )


### PR DESCRIPTION
## Summary

Engine slice (2 of 7) of the `terraflow geoai` integration — epic #90, closes #92. Builds on the #91 foundation. No CLI, no docs, no real `geoai-py` calls yet (those land in #94).

### New module: `terraflow/geoai_engine.py`

Three public runners:

- `run_fields(config_path) -> Path` — wraps `geoai.ftw` → `fields.geojson` + `field_stats.parquet`
- `run_landcover(config_path) -> Path` — wraps `geoai.classify` → `landcover.tif` + `landcover_proba.tif` + `class_fractions.json`
- `run_canopy(config_path) -> Path` — wraps `geoai.canopy` → `canopy_height.tif` + `canopy_stats.json`

Each runner:
- Calls `_require_geoai()` (defensive optional-import guard mirroring `terraflow/export.py:9-14`).
- Validates `config.geoai.engine` matches the runner; rejects configs missing the `geoai:` block.
- Hashes raster via `fingerprint_file()` and computes a deterministic `geoai_fingerprint` via `compute_geoai_fingerprint()` from #91.
- Writes atomically (via existing `_atomic_write_text`) to `<output_dir>/runs/<geoai_fingerprint>/geoai/`.
- Always emits `geoai_manifest.json` (engine, fingerprint, model meta, inputs, config snapshot) and `report.json` (engine, duration, device, torch version, deterministic flag).
- Seeds `torch.manual_seed` from the fingerprint for reproducibility.
- Skips inference on a cache hit (manifest already present).

Engine bodies (`_do_fields`, `_do_landcover`, `_do_canopy`) raise `NotImplementedError` placeholder — real `geoai-py` calls land in #94. Tests monkeypatch them to exercise the orchestration end-to-end without torch installed.

### Deferred-nit carryover from #91 review

Tightens `compute_geoai_fingerprint`:

- Accepts optional `device` (`cpu` / `cuda` / `mps`) and `torch_major_minor` in `model_metadata`; both fold into the hash payload when present. Fixes the #91 review concern that identical inputs on different devices could collide in cache.
- Validates `model_metadata` key set (raises on missing required or unknown keys).
- Validates each `input_fingerprints` entry: must have exactly `{sha256, size_bytes}`. Fixes the silent-drop / `KeyError` ambiguity from #91 review.

## Test plan

- [x] `make lint` — ruff + black clean
- [x] `make typecheck` — mypy clean (18 source files)
- [x] `make test-cov` — **281 passed, 1 skipped**, coverage **87.02%** (≥ 85% floor)
- [x] New tests in `tests/test_geoai_engine.py` (12 cases):
  - `_require_geoai()` raises with the documented install hint.
  - Helpers short-circuit when extra not installed (`_device`, `_torch_major_minor`, `_geoai_major_minor`, `_seed_torch`).
  - `_major_minor` parametrized.
  - Runner rejects wrong engine name; rejects missing `geoai:` block.
  - Each of `run_fields` / `run_landcover` / `run_canopy` writes the expected artifact set, manifest, and report; runner body called exactly once.
  - Cache-hit on re-invocation (runner body not re-called).
  - Threshold bump → new fingerprint → new directory.
- [x] New tests in `tests/test_run_identity.py` (5 cases):
  - Device flip changes hash; torch-minor flip changes hash.
  - Missing required model key → `ValueError`.
  - Unknown model key → `ValueError`.
  - Malformed `input_fingerprints` entry (missing / extra key) → `ValueError`.

## CLAUDE.md scope deviation

CLAUDE.md mandates README / docs / notebook on every PR. Issue #92 explicitly puts those out of scope; user guide + notebook land in #95, real `geoai-py` integration in #94.

## Follow-ups

| MR | Issue | Slice |
|----|-------|-------|
| 3 | #93 | `terraflow geoai` Typer sub-app |
| 4 | #94 | JOSS paper Wu (2026) citation + real `geoai.ftw` / `classify` / `canopy` calls |
| 5 | #95 | User guide + notebook + mkdocs nav |
| 6 | #96 | Demo config block + README |
| 7 | #97 | Opt-in `geoai-tests.yml` workflow |

Refs #90.