### PR TITLE
feat(geoai): add geoai CLI subcommands (#93)

### DIFF
--- a/terraflow/cli.py
+++ b/terraflow/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, Callable
 
 import typer
 
@@ -16,6 +16,67 @@ app = typer.Typer(
     help="TerraFlow: reproducible geospatial agricultural modeling.",
     add_completion=False,
 )
+
+geoai_app = typer.Typer(
+    help="Run optional GeoAI field, landcover, and canopy engines.",
+    add_completion=False,
+)
+
+
+def _config_option() -> Any:
+    return typer.Option(
+        ...,
+        "--config",
+        "-c",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Path to YAML config file",
+    )
+
+
+def _geoai_cmd_factory(engine_name: str, runner_attr: str) -> Callable[[Path], None]:
+    def geoai_cmd(
+        config: Annotated[
+            Path,
+            _config_option(),
+        ],
+    ) -> None:
+        """Run a GeoAI engine."""
+        logger.info(f"TerraFlow GeoAI {engine_name} starting with config: {config}")
+        try:
+            from . import geoai_engine
+
+            runner = getattr(geoai_engine, runner_attr)
+            output_path = runner(config)
+            logger.info(f"GeoAI {engine_name} complete: {output_path}")
+        except ValueError as e:
+            logger.error(f"GeoAI {engine_name} configuration error: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)
+            raise SystemExit(1)
+        except ImportError as e:
+            logger.error(f"Missing dependency: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)
+            raise SystemExit(1)
+        except FileNotFoundError as e:
+            logger.error(f"File not found: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)
+            raise SystemExit(1)
+        except Exception as e:
+            logger.error(f"GeoAI {engine_name} failed: {e}", exc_info=True)
+            print(f"ERROR: GeoAI {engine_name} failed - {e}", file=sys.stderr)
+            raise SystemExit(1)
+
+    geoai_cmd.__name__ = f"geoai_{engine_name}_cmd"
+    geoai_cmd.__doc__ = f"Run GeoAI {engine_name} inference."
+    return geoai_cmd
+
+
+geoai_app.command("fields")(_geoai_cmd_factory("fields", "run_fields"))
+geoai_app.command("landcover")(_geoai_cmd_factory("landcover", "run_landcover"))
+geoai_app.command("canopy")(_geoai_cmd_factory("canopy", "run_canopy"))
+app.add_typer(geoai_app, name="geoai")
 
 
 @app.command("run")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
-from terraflow.cli import main
+from terraflow.cli import app, main
+
+runner = CliRunner()
 
 
 def test_cli_missing_config_arg(capsys):
@@ -228,6 +231,28 @@ def test_cli_help_message(capsys):
     captured = capsys.readouterr()
     assert "run" in captured.out.lower()
     assert "sensitivity" in captured.out.lower()
+
+
+def test_cli_geoai_help_outputs_render():
+    help_invocations = [
+        ["geoai", "--help"],
+        ["geoai", "fields", "--help"],
+        ["geoai", "landcover", "--help"],
+        ["geoai", "canopy", "--help"],
+    ]
+
+    for args in help_invocations:
+        result = runner.invoke(app, args)
+
+        assert result.exit_code == 0
+        assert "--config" in result.output or "fields" in result.output
+
+
+def test_cli_geoai_bogus_command_returns_typer_error():
+    result = runner.invoke(app, ["geoai", "bogus", "-c", "x.yml"])
+
+    assert result.exit_code == 2
+    assert "no such command" in result.output.lower()
 
 
 def test_cli_value_error_from_pipeline(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary

Third slice of the `terraflow geoai` integration for issue #93, stacked on #106 / `feat/geoai-92-engine`.

- Registers a nested `terraflow geoai` Typer app.
- Adds `fields`, `landcover`, and `canopy` commands with `--config/-c`.
- Routes commands to `terraflow.geoai_engine.run_fields`, `run_landcover`, and `run_canopy`.
- Mirrors existing CLI error handling for missing dependencies, bad configs, missing files, and unexpected failures.
- Adds CliRunner smoke coverage for `geoai` help output and unknown subcommands.

Closes #93
Refs #90
Depends on #106

## Test plan

- `uv run --extra dev pytest tests/test_cli.py -q`
- `uv run --extra dev ruff check terraflow/cli.py tests/test_cli.py`
- `uv run --extra dev black --check terraflow/cli.py tests/test_cli.py`
- `uv run --extra dev mypy terraflow/cli.py tests/test_cli.py`

Note: full `uv run --extra dev mypy` still fails on inherited unused `type: ignore` comments in `tests/test_geoai_engine.py` from #106.