### PR TITLE
fix(paper): replace placeholder wu2026geoai with real JOSS citation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- `paper/biblio.bib` `wu2026geoai` entry replaced: it was a placeholder `@misc` with `note = "Manuscript in preparation for JOSS"` and a GitHub URL, but the GeoAI JOSS paper was actually **published 2026-02-03** as Wu, Q. (2026), *GeoAI: A Python package for integrating artificial intelligence with geospatial data analysis and visualization*, Journal of Open Source Software, 11(118), 9605, [doi:10.21105/joss.09605](https://doi.org/10.21105/joss.09605). The bib entry is now a proper `@article` with the real DOI, volume, issue, page, ISSN, and publisher. All five `[@wu2026geoai]` citations in `paper/paper.md` continue to resolve to the same key (no in-body text changes).
+
 ### Added
 - `# AI usage disclosure` section in `paper/paper.md` (now a **required** section per the JOSS review criteria). The section discloses that AI tools were used as a coding assistant during implementation and manuscript drafting, that AI-assisted code is human-reviewed before commit, and that the 289 automated tests on Python 3.10/3.11/3.12 verify correctness (#111).
 - `.github/ISSUE_TEMPLATE/bug_report.yml` (YAML-form bug report including TerraFlow version, Python version, OS, config YAML, repro command, expected vs actual, optional `run_fingerprint`) and `feature_request.yml` (problem / proposal / alternatives / subsystem). `.github/ISSUE_TEMPLATE/config.yml` disables blank issues and surfaces the docs site, reproducibility page, security advisory flow, and contributing guide (#113).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 - `paper/biblio.bib` `wu2026geoai` entry replaced: it was a placeholder `@misc` with `note = "Manuscript in preparation for JOSS"` and a GitHub URL, but the GeoAI JOSS paper was actually **published 2026-02-03** as Wu, Q. (2026), *GeoAI: A Python package for integrating artificial intelligence with geospatial data analysis and visualization*, Journal of Open Source Software, 11(118), 9605, [doi:10.21105/joss.09605](https://doi.org/10.21105/joss.09605). The bib entry is now a proper `@article` with the real DOI, volume, issue, page, ISSN, and publisher. All five `[@wu2026geoai]` citations in `paper/paper.md` continue to resolve to the same key (no in-body text changes).
+- `paper/biblio.bib` `terraflow_zenodo` entry **removed**. It was uncited (no `[@terraflow_zenodo]` anywhere in `paper/paper.md`) and carried the same stale v0.1.5 DOI (`10.5281/zenodo.18490119`) and stale title that were already cleaned out of `CITATION.cff` and the paper frontmatter. The repository URL is the citation handle until JOSS mints the v0.4.0 archive on acceptance.
 
 ### Added
 - `# AI usage disclosure` section in `paper/paper.md` (now a **required** section per the JOSS review criteria). The section discloses that AI tools were used as a coding assistant during implementation and manuscript drafting, that AI-assisted code is human-reviewed before commit, and that the 289 automated tests on Python 3.10/3.11/3.12 verify correctness (#111).

--- a/paper/biblio.bib
+++ b/paper/biblio.bib
@@ -143,12 +143,20 @@
   isbn      = {9780470059975}
 }
 
-@misc{wu2026geoai,
-  title        = {{geoai}: A {P}ython library for {GeoAI} with foundation models},
-  author       = {Wu, Qiusheng},
-  year         = {2026},
-  howpublished = {\url{https://github.com/opengeos/geoai}},
-  note         = {Manuscript in preparation for JOSS}
+@article{wu2026geoai,
+  title     = {{GeoAI}: A {P}ython package for integrating artificial
+               intelligence with geospatial data analysis and visualization},
+  author    = {Wu, Qiusheng},
+  journal   = {Journal of Open Source Software},
+  publisher = {The Open Journal},
+  volume    = {11},
+  number    = {118},
+  pages     = {9605},
+  year      = {2026},
+  month     = feb,
+  issn      = {2475-9066},
+  doi       = {10.21105/joss.09605},
+  url       = {https://doi.org/10.21105/joss.09605}
 }
 
 @book{cressie1993spatial,

--- a/paper/biblio.bib
+++ b/paper/biblio.bib
@@ -52,6 +52,7 @@
   journal = {Journal of Open Research Software},
   volume  = {5},
   number  = {1},
+  pages   = {10},
   year    = {2017},
   doi     = {10.5334/jors.148}
 }

--- a/paper/biblio.bib
+++ b/paper/biblio.bib
@@ -1,13 +1,3 @@
-@software{terraflow_zenodo,
-  title     = {TerraFlow: A Reproducible Workflow for Geospatial Agricultural Modeling},
-  author    = {Marupilla, Gnaneswara and Bayina, Chandhini},
-  year      = {2025},
-  publisher = {Zenodo},
-  doi       = {10.5281/zenodo.18490119},
-  url       = {https://doi.org/10.5281/zenodo.18490119},
-  note      = {Software archive}
-}
-
 @misc{usda_cdl,
   title   = {Cropland Data Layer, 2025},
   author  = {{USDA National Agricultural Statistics Service}},


### PR DESCRIPTION
## Summary

The \`wu2026geoai\` BibTeX entry in \`paper/biblio.bib\` was a \`@misc\` placeholder with \`note = "Manuscript in preparation for JOSS"\` pointing at the GitHub repo. The geoai paper was **actually published 2026-02-03** in JOSS, so the entry now points to the wrong publication state. A JOSS reviewer would have flagged this.

## Real citation (verified via Crossref CSL-JSON)

> Wu, Q. (2026). *GeoAI: A Python package for integrating artificial intelligence with geospatial data analysis and visualization.* **Journal of Open Source Software**, 11(118), 9605. [doi:10.21105/joss.09605](https://doi.org/10.21105/joss.09605)

Source of truth: \`curl -H "Accept: application/vnd.citationstyles.csl+json" https://doi.org/10.21105/joss.09605\`. Verbatim fields:

| field | value |
|---|---|
| title | GeoAI: A Python package for integrating artificial intelligence with geospatial data analysis and visualization |
| author | Wu, Qiusheng (ORCID 0000-0001-5437-4073, Department of Geography & Sustainability, U. Tennessee, Knoxville) |
| journal | Journal of Open Source Software |
| volume | 11 |
| number (issue) | 118 |
| pages | 9605 |
| issued | 2026-02-03 |
| publisher | The Open Journal |
| DOI | 10.21105/joss.09605 |
| ISSN | 2475-9066 |

## What changed

- \`paper/biblio.bib\` — \`@misc{wu2026geoai, ...}\` → \`@article{wu2026geoai, ...}\` with the real DOI, volume, issue, page, ISSN, publisher.
- \`CHANGELOG.md\` — \`[Unreleased]/Fixed\` note explaining the swap.
- **No \`paper/paper.md\` edits needed** — all five \`[@wu2026geoai]\` sites (Summary, Statement of need, State of the field ×2, Software design, Acknowledgements) reuse the same key.

## Test plan

- [x] Confirmed all five \`[@wu2026geoai]\` citations resolve to the new entry: \`grep -n 'wu2026geoai' paper/paper.md\`.
- [ ] CI: \`manuscript.yml\` rebuilds the paper PDF — Wu reference now expands to "Wu, Q. (2026). GeoAI: A Python package…" instead of "Wu, Q. (2026). geoai: A Python library for GeoAI…".
- [ ] All other CI gates unchanged (no code touched).

Tracks as part of the JOSS readiness sweep — see also #111–#116 (already shipped).