### PR TITLE
chore(strategy): scaffold docs/strategy/ for research-impact campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- `docs/strategy/` directory scaffolding for the post-JOSS-rejection research-impact campaign (kicked off 2026-06-24 after editor closed [openjournals/joss-reviews#10686](https://github.com/openjournals/joss-reviews/issues/10686) for "paper too long" + "demonstrated research impact" pre-review screening). `docs/strategy/README.md` indexes per-Part outputs tracked in GitHub issues #123–#130 ([strategy] Parts 1–8); `docs/strategy/auto/README.md` + empty `metrics.csv` scaffold the outputs that scheduled Claude routines will write (adoption metrics, JOSS pulse, ecosystem watch, monthly reviews, Day-90 / Day-180 gate checks). Internal planning artifacts only — intentionally excluded from `mkdocs.yml` nav.
+
 ### Changed
 - All seven notebooks under `docs/notebooks/` re-executed against v0.4.0 so the rendered docs site shows live output for every cell. `05_extended_variogram_mode.ipynb` (previously checked in unexecuted) and `06_geoai_engine.ipynb` (just created) now have execution counts and outputs; `terraflow_v0_2_0_comprehensive_test.ipynb` re-executed so the inline outputs and execution counts are in sync. `kriging_uncertainty_demo.ipynb` header bumped from v0.2.1 → v0.4.0; `terraflow_v0_2_0_comprehensive_test.ipynb` header now frames the notebook as a v0.2.0 → v0.4.0 backward-compatibility regression check.
 - `docs/notebooks/06_geoai_engine.ipynb` stub cell now patches the helper functions (`_device`, `_torch_major_minor`, `_geoai_major_minor`, `_seed_torch`) so the notebook executes cleanly without the `[geoai]` extra installed (previously only `_GEOAI_AVAILABLE` and `_do_fields` were patched, which left `torch.cuda.is_available()` to dereference `None`).

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,19 @@
+# Strategy
+
+Long-horizon planning artifacts produced during the post-JOSS-rejection research-impact campaign (kicked off 2026-06-24 after the editor closed [openjournals/joss-reviews#10686](https://github.com/openjournals/joss-reviews/issues/10686)). Files here are **internal planning material**, not user-facing documentation, and are intentionally excluded from the `mkdocs.yml` nav.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `README.md` | This file. |
+| `part1-impact-definition.md` … `part8-vision.md` | Per-Part outputs of the 8-Part research investigation. Filed under the matching `[strategy] Part N` GitHub issues (#123–#130). |
+| `auto/` | Outputs of scheduled autonomous routines (adoption metrics, JOSS pulse, ecosystem watch, monthly reviews, gate checks). See `auto/README.md`. |
+
+## Source of truth
+
+The execution plan is at `~/.claude/plans/gh-issue-https-github-com-openjournals-j-linear-rabbit.md` (user-private; not in repo). GitHub issues #123–#131 mirror it.
+
+## Why not in mkdocs nav?
+
+These are decision artifacts for the maintainers. Published docs target users; internal strategy lives here without polluting the docs site.

--- a/docs/strategy/auto/README.md
+++ b/docs/strategy/auto/README.md
@@ -1,0 +1,41 @@
+# Autonomous routine outputs
+
+Outputs of scheduled Claude routines (registered via `/schedule`) that run on cron without an interactive session. Tracks the research-impact metrics that JOSS editors weighed when rejecting [openjournals/joss-reviews#10686](https://github.com/openjournals/joss-reviews/issues/10686).
+
+## Files
+
+| File | Routine | Cadence | Notes |
+|------|---------|---------|-------|
+| `metrics.csv` | #1 Adoption metrics scan | Weekly, Mon 09:00 CDT | Append-only. One row per Monday. |
+| `joss-bar.md` | #2 JOSS pulse | Weekly, Wed 09:00 CDT | Overwrite — captures the moving JOSS-acceptance bar. |
+| `ecosystem-YYYY-MM-DD.md` | #3 Ecosystem watch | Weekly, Fri 09:00 CDT | One file per Friday — upstream commit/issue scan. |
+| `monthly-review-YYYY-MM.md` | #4 Roadmap reconciliation | Monthly, 1st | Diff vs. Part-6 plan. Activates after Part 6 ships. |
+| `gate-day90.md`, `gate-day180.md` | #5/#6 Gate checks | One-time | GO / NO-GO / EXTEND-3-MONTHS recommendations. |
+
+## Guardrails
+
+Per plan §C:
+
+1. **Commit budget:** ≤1 file per routine run.
+2. **Halt-on-stale:** routine pauses + opens a GH issue comment after 4 consecutive no-change runs.
+3. **Read-only against code:** routines never touch `terraflow/*.py`.
+4. **No external posts:** never comment on the JOSS issue, never post to third-party repos.
+5. **Cost cap:** ≤10k tokens/run (monthly review excepted).
+
+## metrics.csv schema
+
+| Column | Source | Notes |
+|--------|--------|-------|
+| `date` | run date | ISO YYYY-MM-DD |
+| `stars` | GitHub API | snapshot |
+| `forks` | GitHub API | snapshot |
+| `contributors` | GitHub API | unique authors all-time |
+| `unique_commenters_nonmaintainer` | GitHub API | issue + PR comments excluding @gmarupilla, bots |
+| `open_issues` | GitHub API | excludes PRs |
+| `open_prs` | GitHub API | |
+| `merged_prs_external` | GitHub API | PRs merged from non-maintainer authors |
+| `pypi_downloads_30d` | pypistats API | rolling 30-day for `terraflow-agro` |
+| `crossref_citations` | Crossref API | citations of TerraFlow Zenodo/JOSS DOI (0 until DOI minted) |
+| `code_search_imports` | GitHub code-search | distinct repos containing `import terraflow` (excluding self) |
+
+Final schema decided in Part 4 (#125). This file may extend then.

--- a/docs/strategy/auto/metrics.csv
+++ b/docs/strategy/auto/metrics.csv
@@ -1,0 +1,1 @@
+date,stars,forks,contributors,unique_commenters_nonmaintainer,open_issues,open_prs,merged_prs_external,pypi_downloads_30d,crossref_citations,code_search_imports


### PR DESCRIPTION
## Summary

Scaffolds `docs/strategy/` (internal planning artifacts) for the post-JOSS-rejection research-impact campaign:

- `docs/strategy/README.md` — indexes per-Part outputs of the 8-Part investigation tracked in issues #123–#130
- `docs/strategy/auto/README.md` — documents the 6 scheduled Claude routines (adoption metrics, JOSS pulse, ecosystem watch, monthly reviews, Day-90 / Day-180 gate checks) that will write here, plus the guardrails (commit budget, halt-on-stale, read-only against code, no third-party posts, token cap)
- `docs/strategy/auto/metrics.csv` — header-only file, populated weekly by routine #1
- `CHANGELOG.md` — entry under `[Unreleased] / Added`

**Intentionally excluded from `mkdocs.yml` nav** — strategy/ is internal decision material, not user-facing docs.

**Context:** editor closed [openjournals/joss-reviews#10686](https://github.com/openjournals/joss-reviews/issues/10686) for (1) paper too long, (2) insufficient demonstrated research impact. This PR is the file-layer scaffolding for the recovery campaign whose plan + tracking issues (#123–#131) were created today.

## Test plan

- [ ] CI green (markdown only; no Python touched)
- [ ] `docs/strategy/` does not appear in built MkDocs nav
- [ ] CHANGELOG renders cleanly on PR preview