### PR TITLE
docs: add Zenodo DOI badge + CITATION doi

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,7 @@ type: software
 title: "TerraFlow: A Reproducible Framework for Climate-Impact Assessment of Agricultural Suitability"
 version: 0.5.0
 date-released: "2026-06-30"
+doi: 10.5281/zenodo.21070362
 license: MIT
 repository-code: "https://github.com/gmarupilla/AgroTerraFlow"
 url: "https://terraflow.marupilla.dev"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=gmarupilla_AgroTerraFlow&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=gmarupilla_AgroTerraFlow)
 [![Codecov](https://codecov.io/gh/gmarupilla/AgroTerraFlow/branch/main/graph/badge.svg)](https://codecov.io/gh/gmarupilla/AgroTerraFlow)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/1104263606.svg)](https://doi.org/10.5281/zenodo.21070362)
 
 TerraFlow is a reproducible, config-driven framework for **climate-impact assessment of agricultural suitability**. Give it a land-cover raster, a climate CSV (weather-station observations), and a YAML config — it returns a scored, location-stamped results table with full provenance and per-cell uncertainty intervals. The locked product direction adds climate-induced crop hazards (drought, flood, heat stress, growing-degree-day shifts) under historical and projected future climate (CMIP6 SSP scenarios) in the upcoming v0.5.0 release; the configuration schema is already in place (see [`climate.temporal_aggregations`](https://terraflow.marupilla.dev/config/schema/)), and the ingest + engine PRs land sequentially over the v0.5.0 sprint. The same workflow methodology extends to habitat suitability, land-use planning, and conservation siting.
 


### PR DESCRIPTION
## Summary

v0.5.0 release (#151) triggered the GitHub→Zenodo integration; Zenodo minted concept DOI **10.5281/zenodo.21070362** (always resolves to the latest archived release).

- `README.md`: Zenodo badge added under License badge using the markdown Zenodo provides.
- `CITATION.cff`: `doi:` field restored (concept DOI). It was previously removed because the only available DOI pointed at the stale v0.1.5 archive — now we have a valid v0.5.0+ archive.

JOSS resubmission requires a Zenodo archive DOI; this closes that gap.

## Test plan
- [x] mkdocs builds clean
- [x] README badge points to the DOI's resolver URL (verified by clicking on the rendered badge)