### PR TITLE
docs: fix run-identity + paper claims that drifted ahead of v0.5.0

### DIFF
--- a/docs/architecture/run-identity.md
+++ b/docs/architecture/run-identity.md
@@ -96,6 +96,7 @@ without re-scoring (**no-op rerun**).
 | Same run directory → same `features.parquet` schema | Schema version frozen in Parquet metadata |
 | Different input content → different fingerprint | SHA-256 collision probability negligible |
 | Filesystem copy / CI clone → same fingerprint | mtime excluded from hash |
+| Random cell sampling reproducible across runs | `numpy.random.default_rng(seed)` initialised with first 64 bits of `sha256(run_fingerprint)` (`pipeline.py`) |
 
 ---
 
@@ -104,8 +105,3 @@ without re-scoring (**no-op rerun**).
 - The fingerprint covers **declared** input files (raster, climate CSV, ROI
   GeoJSON) only.  If a pipeline step reads additional files not listed in the
   config, those are not tracked.
-- Random cell sampling (`max_cells < n_valid_cells`) means the **cell set
-  may differ between runs even with the same fingerprint** — because
-  `random.sample` is seeded by Python's default PRNG, not by the fingerprint.
-  For fully deterministic cell selection, seed the PRNG via the config
-  (planned for a future release; tracked in ROADMAP).

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,11 +34,11 @@ TerraFlow is an open-source Python library for **reproducible
 climate-impact assessment of agricultural suitability**. It turns a
 land-cover raster, weather-station observations, and a YAML configuration
 into a scored per-cell suitability table with complete, machine-readable
-provenance and per-cell uncertainty intervals. The locked product
-direction adds climate-induced crop hazards (drought, flood, heat stress,
-growing-degree-day shifts) under historical and projected future climate
-(CMIP6 SSP scenarios) in the next release; the configuration schema is
-already in place and the ingest + engine ships sequentially in v0.5.0. A single `terraflow run` clips the raster to a
+provenance and per-cell uncertainty intervals. As of v0.5.0 the framework
+also fans out climate-induced crop hazards (growing-degree days, frost
+days, heat-stress days, precipitation percentiles, simplified Thornthwaite
+SPEI) across arbitrary scenario windows, with CMIP6 NetCDF ingestion via
+the optional `[cmip6]` extra. A single `terraflow run` clips the raster to a
 region of interest, reprojects it to WGS84, spatially interpolates
 station climate to cell centroids (linear, inverse-distance, or Ordinary
 Kriging with automatic variogram selection), computes a normalised

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -69,9 +69,12 @@ depend on file paths, package versions, and random seeds that drift
 silently between runs; interpolation uncertainty and parameter
 sensitivity are rarely quantified; and reviewers cannot regenerate a
 specific figure from a specific configuration and specific input bytes.
-TerraFlow's roadmap adds CMIP6 NetCDF ingest for projected-climate
-scenarios in v0.5.0, but the reproducibility gap exists today on the
-historical pipeline alone.
+v0.5.0 closes one half of this gap: a config-level scenario × hazard
+fan-out now ingests CMIP6 NetCDF inputs and folds each file's SHA-256
+into the run fingerprint, so projected-climate analyses inherit the
+same reproducibility contract as the historical pipeline. The other
+half — adoption-driven validation of those projections against
+domain-specific benchmarks — is in progress.
 
 TerraFlow closes this gap with a single configuration-driven pipeline
 that fingerprints every run from the canonicalised YAML config plus


### PR DESCRIPTION
## Summary

Two doc/paper claims caught by an external Codex review of v0.5.0. Both are JOSS-fatal if left unfixed before resubmission — a reviewer cross-referencing the code against the docs will spot them.

## Fixes

1. **`docs/architecture/run-identity.md`** — under "Limitations" we still claimed random cell sampling "may differ between runs even with the same fingerprint" because `random.sample` is unseeded. `terraflow/pipeline.py:730` (since #138f) actually seeds `numpy.random.default_rng` from `sha256(run_fingerprint)`. Moved the now-accurate statement out of "Limitations" and into the "Reproducibility guarantees" table.

2. **`paper/paper.md`** — Summary said climate-induced crop hazards + CMIP6 SSP scenarios arrive "in the next release". v0.5.0 IS that release. Past-tensed the framing: "As of v0.5.0 the framework also fans out climate-induced crop hazards (GDD, frost days, heat-stress days, precipitation percentiles, simplified Thornthwaite SPEI) across arbitrary scenario windows, with CMIP6 NetCDF ingestion via the optional `[cmip6]` extra."

## Verify

- [x] `mkdocs build --strict` — clean
- [x] No tests touched