### PR TITLE
docs: full v0.5.0 sweep — API ref for 4 new modules + citation + roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flowchart LR
 | **Sensitivity analysis** | Sobol' / Morris indices for model weights (`terraflow sensitivity`) |
 | **Uncertainty quantification** | Kriging Monte Carlo → score CIs (`score_ci_low` / `score_ci_high`) |
 | **Distribution** | PyPI (`terraflow-agro`) + Homebrew (`gmarupilla/terraflow`) + Docker |
-| **Citation** | Citable via `CITATION.cff`; JOSS paper in preparation |
+| **Citation** | Citable via `CITATION.cff` and Zenodo DOI [10.5281/zenodo.21070362](https://doi.org/10.5281/zenodo.21070362); JOSS paper resubmission pending adoption signal |
 
 ---
 
@@ -199,7 +199,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Citation
 
-If you use TerraFlow in your research, please cite our JOSS paper (manuscript in preparation).
+If you use TerraFlow in your research, please cite the archived Zenodo
+release:
+
+> Marupilla, G. (2026). *TerraFlow: A Reproducible Framework for
+> Climate-Impact Assessment of Agricultural Suitability* (v0.5.0).
+> Zenodo. https://doi.org/10.5281/zenodo.21070362
+
+`CITATION.cff` carries the canonical metadata. A companion JOSS paper is
+drafted and will be resubmitted once external adoption signal materialises;
+see the postmortem at https://github.com/openjournals/joss-reviews/issues/10686.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![DOI](https://zenodo.org/badge/1104263606.svg)](https://doi.org/10.5281/zenodo.21070362)
 
-TerraFlow is a reproducible, config-driven framework for **climate-impact assessment of agricultural suitability**. Give it a land-cover raster, a climate CSV (weather-station observations), and a YAML config — it returns a scored, location-stamped results table with full provenance and per-cell uncertainty intervals. The locked product direction adds climate-induced crop hazards (drought, flood, heat stress, growing-degree-day shifts) under historical and projected future climate (CMIP6 SSP scenarios) in the upcoming v0.5.0 release; the configuration schema is already in place (see [`climate.temporal_aggregations`](https://terraflow.marupilla.dev/config/schema/)), and the ingest + engine PRs land sequentially over the v0.5.0 sprint. The same workflow methodology extends to habitat suitability, land-use planning, and conservation siting.
+TerraFlow is a reproducible, config-driven framework for **climate-impact assessment of agricultural suitability**. Give it a land-cover raster, a climate CSV (weather-station observations), and a YAML config — it returns a scored, location-stamped per-cell results table with full provenance and per-cell uncertainty intervals. As of **v0.5.0** the framework also fans out climate-induced crop hazards (growing-degree days, frost days, heat-stress days, precipitation percentiles, simplified Thornthwaite SPEI) across arbitrary CMIP6 SSP scenario windows, writing a sibling `climate_features.parquet` artifact alongside the historical suitability score. The same workflow methodology extends to habitat suitability, land-use planning, and conservation siting.
 
 **Documentation:** [terraflow.marupilla.dev](https://terraflow.marupilla.dev) — see the [Reproducibility page](https://terraflow.marupilla.dev/reproducibility/) for what the run fingerprint covers and known sources of non-determinism.
 
@@ -116,11 +116,11 @@ report.json        — QA stats and timings
 
 | Subcommand | Purpose |
 |---|---|
-| `terraflow run -c config.yml` | Run the full pipeline |
+| `terraflow run -c config.yml` | Run the full pipeline. Auto-invokes the climate-impact path (scenario × hazard fan-out) when both `climate.temporal_aggregations` and `climate.scenarios` are set in the config. |
 | `terraflow sensitivity -c config.yml` | Sobol' / Morris sensitivity indices for model weights |
 | `terraflow validate -c config.yml` | Spatial block CV |
 
-See [CLI docs](https://terraflow.marupilla.dev/cli/usage/) for full reference.
+See [CLI docs](https://terraflow.marupilla.dev/cli/usage/) for full reference. End-to-end climate-impact example: [`examples/demo_config_climate_impact.yml`](examples/demo_config_climate_impact.yml) + the [demo notebook](https://terraflow.marupilla.dev/notebooks/07_climate_impact_crop_suitability/).
 
 ## Climate interpolation
 
@@ -158,7 +158,7 @@ make docs-build
 
 ## Architecture
 
-Core modules: `cli`, `config`, `climate`, `core/run_identity`, `exceptions`, `export`, `geo`, `ingest`, `model`, `pipeline`, `sensitivity`, `stats`, `utils`, `validation`, `viz`.
+Core modules: `cli`, `config`, `pipeline`, `model`, `ingest`, `geo`, `climate`, `climate_impact`, `temporal`, `hazard`, `cmip6`, `sensitivity`, `validation`, `core/run_identity`, `stats`, `exceptions`, `utils`, `viz`.
 
 Run artifacts under `<output_dir>/runs/<fingerprint>/` include `features.parquet`, `manifest.json`, `report.json`, and `results.csv`. When kriging is configured, `report.json` also carries `kriging_diagnostics` (model, nugget, sill, range), `kriging_loocv` RMSE per variable, `uncertainty` coverage, and an `interpolation_fallback` block with per-variable fallback-to-mean counts. Multi-band rasters are supported via the top-level `raster_band` field (1-based; default `1`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ tags:
 
 # TerraFlow Roadmap
 
-This roadmap tracks completed phases and current state. v0.5.0 (2026-06-30) refocused the surface on the climate-impact flagship: removed GeoAI + H3 wrappers, narrowed validation to spatial-block CV, and shipped scenario × hazard fan-out with CMIP6 NetCDF support. Package restructure into `terraflow.io.*` + `terraflow.climate.*` sub-packages is planned for v0.6.0 (issue #148).
+This roadmap tracks completed phases and current state. v0.5.0 (2026-06-30) refocused the surface on the climate-impact flagship: removed GeoAI + H3 wrappers, narrowed validation to spatial-block CV, and shipped scenario × hazard fan-out with CMIP6 NetCDF support. The next release (v0.6.0) makes CMIP6 ingestion first-class in the pipeline (`climate.cmip6_scenarios:` config block, unit conversion, NetCDF SHA-256 in `manifest.json`); package restructure into `terraflow.io.*` + `terraflow.climate.*` sub-packages slips to v0.7.0 (issue #148).
 
 JOSS pre-review submitted 2026-06-08, rejected 2026-06-24 on impact criteria. **Resubmission gated on adoption signal**, not code (see internal strategy repo).
 

--- a/docs/api/climate_impact.md
+++ b/docs/api/climate_impact.md
@@ -1,0 +1,62 @@
+---
+title: Climate Impact API
+description: API reference for terraflow.climate_impact — scenario × hazard orchestrator producing climate_features.parquet.
+icon: material/chart-timeline-variant
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.climate_impact
+
+Climate-impact pipeline orchestrator introduced in v0.5.0 (#138e). Glues
+`terraflow.temporal.compute_per_station_aggregations` to
+`terraflow.climate.ClimateInterpolator` and writes the sibling
+`climate_features.parquet` artifact alongside the historical
+`features.parquet`.
+
+The orchestrator is auto-invoked by `terraflow.pipeline.run_pipeline`
+when the loaded config declares both `climate.temporal_aggregations`
+and `climate.scenarios` (since v0.5.0; #138f). It is also exposed as a
+public function for callers that want to drive the climate-impact path
+without going through the full pipeline.
+
+## Overview
+
+- `load_timeseries_csv(path)` — parse and validate the long-format
+  station daily CSV. Required columns: `station_id, lat, lon, date,
+  temperature_c, precipitation_mm`.
+- `run_climate_impact_features(cfg, run_dir, cells_df)` — orchestrate
+  the full path: compute per-station aggregations, kriging-interpolate
+  each `<rule>__<scenario>` column to cell centroids, write the
+  artifact. Returns the absolute path to `climate_features.parquet`.
+
+## Artifact contract
+
+| Column | Type | Meaning |
+|---|---|---|
+| `cell_id` | int | Stable within a run; matches `features.parquet.cell_id` |
+| `<rule_label>__<scenario_name>` | float | One column per `TemporalAggregation × Scenario` pair |
+
+Merge with `features.parquet` on `cell_id` for a complete cell-level
+panel.
+
+## Quick example
+
+```python
+import pandas as pd
+from terraflow.pipeline import run_pipeline
+
+df = run_pipeline("examples/demo_config_climate_impact.yml")
+run_dir = df.attrs["run_dir"]
+
+features = pd.read_parquet(f"{run_dir}/features.parquet")
+climate  = pd.read_parquet(f"{run_dir}/climate_features.parquet")
+panel    = features.merge(climate, on="cell_id")
+
+# panel now has historical suitability + every <rule>__<scenario> column.
+```
+
+## API Reference
+
+::: terraflow.climate_impact

--- a/docs/api/cmip6.md
+++ b/docs/api/cmip6.md
@@ -1,0 +1,69 @@
+---
+title: CMIP6 API
+description: API reference for terraflow.cmip6 — CMIP6 NetCDF scenario ingest behind the optional [cmip6] extra.
+icon: material/database-outline
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.cmip6
+
+CMIP6 NetCDF scenario ingest behind the optional `[cmip6]` install extra.
+The module opens climate scenario NetCDFs (typically daily `tas` or `pr`
+cubes), samples them at station coordinates, and returns the long-format
+station time-series that the `terraflow.temporal` aggregation engine
+consumes.
+
+## Install
+
+```bash
+pip install "terraflow-agro[cmip6]"
+```
+
+This installs `xarray>=2024.1` and `netcdf4>=1.7`. They are imported lazily
+inside each callable so users on the historical CSV path never pay the
+import cost.
+
+## Overview
+
+- `cmip6_metadata(path)` — SHA-256 + size + CMIP6 global attrs
+  (variant_label, source_id, experiment_id, institution_id, table_id).
+  Folded into the run fingerprint by the pipeline so different CMIP6
+  variants of the same SSP scenario yield distinct cache directories.
+- `load_cmip6_scenario(path, variable, period)` — opens a NetCDF lazily
+  and slices the time axis by an inclusive `(year_min, year_max)` window.
+  Handles non-Gregorian calendars (`365_day`, `noleap`, `360_day`) via the
+  calendar-aware `dt.year` path.
+- `extract_station_timeseries(da, stations, output_variable)` — vectorised
+  nearest-neighbour selection at station coordinates. Returns a DataFrame
+  in the shape `(station_id, lat, lon, date, <output_variable>)`.
+- `cmip6_to_station_timeseries(path, stations, ...)` — one-call wrapper
+  around the previous two.
+
+Tolerates both `lat`/`lon` and `latitude`/`longitude` coord names commonly
+seen across CMIP6 sources.
+
+## Quick example
+
+```python
+import pandas as pd
+from terraflow.cmip6 import cmip6_to_station_timeseries
+
+stations = pd.DataFrame({
+    "station_id": ["KS01", "KS02", "KS03"],
+    "lat":        [38.5,   39.0,   39.5],
+    "lon":        [-100.5, -100.0, -99.5],
+})
+
+ts = cmip6_to_station_timeseries(
+    "data/cmip6/tas_day_MPI-ESM1-2-HR_historical_19910101-20201231.nc",
+    stations,
+    period=(1991, 2020),
+    output_variable="temperature_c",
+)
+```
+
+## API Reference
+
+::: terraflow.cmip6

--- a/docs/api/cmip6.md
+++ b/docs/api/cmip6.md
@@ -29,8 +29,15 @@ import cost.
 
 - `cmip6_metadata(path)` — SHA-256 + size + CMIP6 global attrs
   (variant_label, source_id, experiment_id, institution_id, table_id).
-  Folded into the run fingerprint by the pipeline so different CMIP6
-  variants of the same SSP scenario yield distinct cache directories.
+  Exposed as a public helper so callers can fold NetCDF provenance into
+  their own manifest. The main `terraflow run` pipeline does **not** yet
+  ingest NetCDFs directly — users today convert each NetCDF to a long-format
+  station CSV via `cmip6_to_station_timeseries(...)` and the CSV's
+  SHA-256 enters the run fingerprint via the existing
+  `_collect_input_paths` path. First-class `climate.cmip6_scenarios:`
+  config support (per-NetCDF SHA-256 + unit conversion + calendar handling
+  inside the pipeline) ships in v0.6.0 — see
+  [issue #148](https://github.com/gmarupilla/AgroTerraFlow/issues/148).
 - `load_cmip6_scenario(path, variable, period)` — opens a NetCDF lazily
   and slices the time axis by an inclusive `(year_min, year_max)` window.
   Handles non-Gregorian calendars (`365_day`, `noleap`, `360_day`) via the

--- a/docs/api/hazard.md
+++ b/docs/api/hazard.md
@@ -1,0 +1,62 @@
+---
+title: Hazard API
+description: API reference for terraflow.hazard — GDD, frost days, heat-stress days, and simplified SPEI implementations.
+icon: material/alert-octagon-outline
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.hazard
+
+WMO/ETCCDI-aligned hazard indicators introduced in v0.5.0 (#138d).
+Backs four of the `TemporalAggregation.kind` values that
+`terraflow.temporal.aggregate_per_station` dispatches to.
+
+## Overview
+
+- `growing_degree_days(df, base_temp_c)` — per-station sum of
+  `max(0, T_d - base)` over each year, averaged across the input window.
+- `frost_days(df, threshold_c)` — per-station count of days where
+  `T ≤ threshold`. WMO ETCCDI **FD0** when threshold = 0 °C.
+- `heat_stress_days(df, threshold_c)` — per-station count of days where
+  `T ≥ threshold`. WMO ETCCDI **TX35** when threshold = 35 °C.
+- `spei(df, timescale_months)` — simplified Thornthwaite-PET-based
+  Standardised Precipitation-Evapotranspiration Index at the final month
+  of the input window.
+
+## SPEI simplifications
+
+Documented honestly so a user can decide whether the simplification is
+acceptable for their analysis:
+
+| Aspect | Canonical SPEI (R package) | TerraFlow `spei()` |
+|---|---|---|
+| Standardisation | Log-logistic CDF fit | **Z-score** |
+| Daylight-hour correction | Latitude-dependent in PET | **Omitted** |
+| Heat-index reference | Multi-decade climatology | **Per-station fit on input window** |
+
+For relative scenario comparisons (e.g. "is SSP5-8.5 drier than
+historical?") these simplifications are typically acceptable. For
+absolute SPEI claims against published thresholds (e.g. "moderate
+drought" at SPEI < -1) prefer the canonical R package via reticulate or
+a pre-computed SPEI column passed through `precip_percentile` as a
+substitute.
+
+## Quick example
+
+```python
+import pandas as pd
+from terraflow.hazard import growing_degree_days, frost_days, heat_stress_days, spei
+
+df = pd.read_csv("data/demo_timeseries.csv", parse_dates=["date"])
+
+gdd = growing_degree_days(df, base_temp_c=10.0)
+fd  = frost_days(df,        threshold_c=0.0)
+ts  = heat_stress_days(df,  threshold_c=35.0)
+spei3 = spei(df, timescale_months=3)
+```
+
+## API Reference
+
+::: terraflow.hazard

--- a/docs/api/hazard.md
+++ b/docs/api/hazard.md
@@ -15,12 +15,22 @@ Backs four of the `TemporalAggregation.kind` values that
 
 ## Overview
 
-- `growing_degree_days(df, base_temp_c)` — per-station sum of
-  `max(0, T_d - base)` over each year, averaged across the input window.
-- `frost_days(df, threshold_c)` — per-station count of days where
-  `T ≤ threshold`. WMO ETCCDI **FD0** when threshold = 0 °C.
-- `heat_stress_days(df, threshold_c)` — per-station count of days where
-  `T ≥ threshold`. WMO ETCCDI **TX35** when threshold = 35 °C.
+- `growing_degree_days(df, base_temp_c)` — per-station **cumulative**
+  sum of `max(0, T_d - base)` across every row in the
+  (scenario-filtered) DataFrame. Note: this is a window-cumulative total,
+  not a per-year average — a 30-year scenario window yields ~30× the
+  value of a 1-year window. Divide by `(year_max - year_min + 1)` if you
+  need an annualised GDD.
+- `frost_days(df, threshold_c)` — per-station **cumulative** count of
+  days where `T ≤ threshold` across every row in the (scenario-filtered)
+  DataFrame. Maps to WMO ETCCDI **FD0** when threshold = 0 °C, but note
+  the WMO definition is per-year — TerraFlow's implementation returns the
+  window total. Divide by the window's year count for the canonical
+  annual FD0.
+- `heat_stress_days(df, threshold_c)` — per-station **cumulative** count
+  of days where `T ≥ threshold` across every row in the (scenario-filtered)
+  DataFrame. Maps to WMO ETCCDI **TX35** when threshold = 35 °C; same
+  per-year vs window-total caveat as `frost_days` above.
 - `spei(df, timescale_months)` — simplified Thornthwaite-PET-based
   Standardised Precipitation-Evapotranspiration Index at the final month
   of the input window.

--- a/docs/api/temporal.md
+++ b/docs/api/temporal.md
@@ -1,0 +1,68 @@
+---
+title: Temporal API
+description: API reference for terraflow.temporal — multi-temporal climate aggregation engine driving the scenario × hazard fan-out.
+icon: material/calendar-clock-outline
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.temporal
+
+Multi-temporal climate aggregation engine introduced in v0.5.0 (#138b).
+Computes per-station aggregations of a long-format daily climate
+time-series and fans them out across configured scenarios. The output
+is the cell-input that `terraflow.climate_impact` interpolates to the
+suitability grid.
+
+## Overview
+
+- `filter_scenario(df, scenario)` — slice a long-format station
+  time-series to a `Scenario.period` year window.
+- `aggregate_per_station(df, rule)` — dispatch a `TemporalAggregation`
+  to its kind-specific implementation. Returns one scalar per station.
+- `compute_per_station_aggregations(df, rules, scenarios)` — outer
+  product. Returns a DataFrame indexed by `station_id` with columns
+  `<rule_label>__<scenario_name>` (one per rule × scenario pair).
+
+Supported `kind` values (declared on `ClimateConfig.temporal_aggregations`):
+
+| kind | Required fields | Notes |
+|---|---|---|
+| `annual_mean` | — | Long-run mean of `temperature_c`. |
+| `seasonal_mean` | `months: [1..12]` | Mean over selected calendar months. |
+| `growing_degree_days` | `base_temp_c: float` | Sum of `max(0, T - base)` per year, mean over window. Implementation in `terraflow.hazard`. |
+| `frost_days` | `threshold_c: float` | Count of days at-or-below threshold. WMO ETCCDI FD0 when threshold = 0. |
+| `heat_stress_days` | `threshold_c: float` | Count of days at-or-above threshold. WMO ETCCDI TX35 when threshold = 35. |
+| `precip_percentile` | `percentile: 0..100` | Nth percentile of daily precipitation. |
+| `spei` | `timescale_months: int > 0` | Simplified Thornthwaite SPEI at the final month of the input window. Implementation in `terraflow.hazard`. |
+
+Stations with no rows after a scenario filter resolve to `NaN` so downstream
+kriging LOOCV sees missing values cleanly rather than silently dropping
+stations.
+
+## Quick example
+
+```python
+import pandas as pd
+from terraflow.temporal import compute_per_station_aggregations
+from terraflow.config import TemporalAggregation, Scenario
+
+df = pd.read_csv("data/demo_timeseries.csv", parse_dates=["date"])
+rules = [
+    TemporalAggregation(kind="annual_mean"),
+    TemporalAggregation(kind="growing_degree_days", base_temp_c=10.0),
+]
+scenarios = [
+    Scenario(name="historical", period=[1991, 2020]),
+    Scenario(name="ssp245",     period=[2041, 2070]),
+]
+panel = compute_per_station_aggregations(df, rules, scenarios)
+panel.head()
+#         annual_mean__historical  annual_mean__ssp245  ...
+# KS01                       12.4                15.1
+```
+
+## API Reference
+
+::: terraflow.temporal

--- a/docs/api/temporal.md
+++ b/docs/api/temporal.md
@@ -31,9 +31,9 @@ Supported `kind` values (declared on `ClimateConfig.temporal_aggregations`):
 |---|---|---|
 | `annual_mean` | — | Long-run mean of `temperature_c`. |
 | `seasonal_mean` | `months: [1..12]` | Mean over selected calendar months. |
-| `growing_degree_days` | `base_temp_c: float` | Sum of `max(0, T - base)` per year, mean over window. Implementation in `terraflow.hazard`. |
-| `frost_days` | `threshold_c: float` | Count of days at-or-below threshold. WMO ETCCDI FD0 when threshold = 0. |
-| `heat_stress_days` | `threshold_c: float` | Count of days at-or-above threshold. WMO ETCCDI TX35 when threshold = 35. |
+| `growing_degree_days` | `base_temp_c: float` | **Cumulative** sum of `max(0, T - base)` across every row in the scenario window — divide by year count for annualised GDD. Implementation in `terraflow.hazard`. |
+| `frost_days` | `threshold_c: float` | **Window-cumulative** count of days at-or-below threshold. WMO ETCCDI FD0 (when threshold = 0) is per-year — divide by year count for the canonical annual value. |
+| `heat_stress_days` | `threshold_c: float` | **Window-cumulative** count of days at-or-above threshold. WMO ETCCDI TX35 (when threshold = 35) is per-year — divide by year count for the canonical annual value. |
 | `precip_percentile` | `percentile: 0..100` | Nth percentile of daily precipitation. |
 | `spei` | `timescale_months: int > 0` | Simplified Thornthwaite SPEI at the final month of the input window. Implementation in `terraflow.hazard`. |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,10 @@ nav:
       - terraflow.ingest: api/ingest.md
       - terraflow.geo: api/geo.md
       - terraflow.climate: api/climate.md
+      - terraflow.cmip6: api/cmip6.md
+      - terraflow.temporal: api/temporal.md
+      - terraflow.hazard: api/hazard.md
+      - terraflow.climate_impact: api/climate_impact.md
       - terraflow.model: api/model.md
       - terraflow.stats: api/stats.md
       - terraflow.sensitivity: api/sensitivity.md


### PR DESCRIPTION
## Summary

Honest answer to "are the docs really up to date?" — they were not. Found four real misses on a careful sweep:

1. **`docs/ROADMAP.md`** intro said the package restructure was planned for v0.6.0. After the Codex review the v0.6.0 scope swapped (CMIP6 first-class becomes v0.6.0; restructure slips to v0.7.0). Updated.

2. **`README.md`** Citation table row and Citation section still said "JOSS paper in preparation." Now that the Zenodo DOI is minted and JOSS pre-review rejected, the canonical citation handle is the DOI. Replaced with an explicit APA-style citation + one-line note on JOSS resubmission status.

3. **`docs/api/`** was missing pages for the four new public modules added in v0.5.0:
   - `terraflow.cmip6` (CMIP6 NetCDF ingest)
   - `terraflow.temporal` (multi-temporal aggregation engine)
   - `terraflow.hazard` (WMO/ETCCDI hazard indicators)
   - `terraflow.climate_impact` (scenario × hazard orchestrator)

   Each new page mirrors the existing `climate.md` / `ingest.md` template (frontmatter, overview, quick example, mkdocstrings `:::` block). The hazard page documents every SPEI simplification (z-score vs canonical log-logistic, no daylight correction, per-window heat-index fit) so users can decide if it's acceptable.

4. **`mkdocs.yml`** API Reference nav extended to surface all four new pages.

## Verify

- [x] `pytest -q` — 300 passed, 1 skipped
- [x] `mkdocs build --strict` — no warnings
- [x] Exhaustive `grep -rEn` for `v0.4.0`, `GeoAI`, `geoai`, `[h3]`, `to_h3`, `cohen_kappa:`, `morans_i_residuals`, `reference_csv:`, "JOSS paper in preparation", "manuscript in preparation", "next release" comes back clean (remaining matches are intentional historical documentation of what was cut).