### PR TITLE
docs: architecture diagrams — full v0.5.0 sweep

### DIFF
--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -30,9 +30,11 @@ flowchart TD
         I --> J[Artifact Generation]
     end
     
-    J --> K[results.csv]
-    J --> L[fingerprint.json]
-    J --> M[results.html]
+    J --> K[features.parquet]
+    J --> L[manifest.json]
+    J --> M[report.json]
+    J --> N[climate_features.parquet<br/>v0.5.0; when configured]
+    J --> O[results.csv<br/>backward-compat]
     
     style Ingest fill:#00b0ff,stroke:#0091ea,color:#fff
     style Core fill:#2d8a55,stroke:#1e5c3a,color:#fff

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -26,22 +26,31 @@ climate.py → ClimateInterpolator (linear | kriging | IDW)
                  ↓
 model.py → suitability_score() + suitability_label()
                  ↓
-pipeline.py → write artifacts to output_dir/runs/<fingerprint>/
+pipeline.py → write features.parquet, manifest.json, report.json
+                 ↓
+climate_impact.py → (auto-invoked when temporal_aggregations + scenarios)
+                    temporal.py × hazard.py → kriging to cells
+                 ↓
+pipeline.py → write climate_features.parquet to same run directory
 ```
 
 ## Module Map
 
 | Module | Responsibility |
 |--------|---------------|
-| `cli.py` | Typer CLI — `run`, `sensitivity`, `validate`, `export` subcommands |
-| `config.py` | Pydantic v2 models — `PipelineConfig`, `ModelParams`, `ROI`, `SensitivityConfig`, `ValidationConfig`, `ExportConfig` |
+| `cli.py` | Typer CLI — `run`, `sensitivity`, `validate` subcommands |
+| `config.py` | Pydantic v2 models — `PipelineConfig`, `ModelParams`, `ROI`, `ClimateConfig` (`temporal_aggregations`, `scenarios`, `timeseries_csv`), `TemporalAggregation`, `Scenario`, `SensitivityConfig`, `ValidationConfig` |
 | `ingest.py` | `RasterLayer`, `ClimateLayer`, `DataCatalog` — metadata only, no pixel I/O |
 | `geo.py` | ROI clipping, CRS reprojection; invariant: all output in EPSG:4326 |
 | `climate.py` | `ClimateInterpolator` — linear / kriging / IDW; LOOCV variogram selection |
+| `climate_impact.py` | `run_climate_impact_features` — auto-invoked from `pipeline.run_pipeline` when `temporal_aggregations` + `scenarios` are set; writes `climate_features.parquet` |
+| `temporal.py` | Multi-temporal aggregation engine — outer-product over rules × scenarios |
+| `hazard.py` | WMO/ETCCDI-aligned indicators — `growing_degree_days`, `frost_days`, `heat_stress_days`, simplified Thornthwaite `spei` |
+| `cmip6.py` | CMIP6 NetCDF ingest behind `[cmip6]` optional extra — handles non-Gregorian calendars |
 | `model.py` | `suitability_score()`, `suitability_label()`, `suitability_score_array()` |
-| `pipeline.py` | Orchestration — fingerprint → load → clip → interpolate → score → write |
+| `pipeline.py` | Orchestration — fingerprint → load → clip → interpolate → score → write; auto-invokes `climate_impact` when configured |
 | `sensitivity.py` | Sobol' / Morris via SALib — triggered by `terraflow sensitivity` |
-| `validation.py` | Spatial block CV — triggered by `terraflow validate` |
+| `validation.py` | Spatial-block CV only (Cohen's κ + Moran's I removed in v0.5.0) — triggered by `terraflow validate` |
 | `core/run_identity.py` | Deterministic SHA256 fingerprint of canonicalized config + input files |
 
 ## Output Artifacts
@@ -51,7 +60,8 @@ All artifacts land under `<output_dir>/runs/<run_fingerprint>/`:
 | File | Schema | Contents |
 |------|--------|----------|
 | `features.parquet` | v1 | `run_id, cell_id, lat, lon, v_index, mean_temp, total_rain, score, label` (+ kriging std + CI columns when configured) |
-| `manifest.json` | v1 | Config snapshot, input fingerprints, code version, git SHA |
+| `climate_features.parquet` | v1 | (v0.5.0) Cell-indexed; one column per `<rule>__<scenario>` pair. Only written when `temporal_aggregations` + `scenarios` are set. Merge with `features.parquet` on `cell_id`. |
+| `manifest.json` | v1 | Config snapshot, input fingerprints (raster + climate CSV + `timeseries_csv` when set), code version, git SHA |
 | `report.json` | v1 | Coverage fractions, raster/climate stats, score stats, timings; `kriging_loocv`, `kriging_diagnostics`, `uncertainty`, and `validation` blocks appended when the relevant features are enabled |
 | `results.csv` | — | Same data as `features.parquet` in CSV format (backward compatibility) |
 | `sensitivity_report.json` | — | Sobol' and/or Morris indices per `ModelParams` weight (written by `terraflow sensitivity`) |
@@ -69,7 +79,7 @@ All artifacts land under `<output_dir>/runs/<run_fingerprint>/`:
 The `run_fingerprint` is a SHA256 over:
 1. Canonicalized (key-sorted) YAML config
 2. A stable ROI geometry hash (bbox dict or GeoJSON file hash)
-3. SHA256 fingerprints of all input files (raster + CSV)
+3. SHA256 fingerprints of all input files (raster + climate CSV + `timeseries_csv` when set for the climate-impact path)
 
 This makes each run directory immutable. Re-running with identical inputs is a no-op; changing any input or config parameter produces a new directory.
 

--- a/docs/field-guide.md
+++ b/docs/field-guide.md
@@ -29,7 +29,7 @@ flowchart LR
     A[Land Cover Map] --> D[TerraFlow Pipeline]
     B[Climate Data] --> D
     C[Configuration] --> D
-    D --> E[results.csv]
+    D --> E[features.parquet<br/>+ results.csv]
     E --> F[Excel/QGIS]
     E --> G[Interactive Map]
     

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,7 +70,7 @@ flowchart TD
     F --> |temperature x w_t| G
     F --> |rainfall x w_r| G
     G --> H[Generate labels]
-    H --> I[Write results.csv]
+    H --> I[Write features.parquet<br/>+ results.csv]
     I --> J["cell_id, lat, lon, score, label"]
 
     style A fill:#2d8a55,stroke:#1e5c3a,color:#fff


### PR DESCRIPTION
## Summary

Five v0.5.0 mismatches across architecture-relevant diagrams and flow descriptions, found after your "all architecture diagrams?" prompt:

| File | Issue | Fix |
|---|---|---|
| `docs/architecture/overview.md` | Data flow ASCII art stopped at "write artifacts"; module map listed removed `export` + `ExportConfig` and was missing 4 new v0.5.0 modules; artifact table missed `climate_features.parquet`; repro model missed `timeseries_csv` | Updated all four |
| `docs/architecture/boundaries.md` | Mermaid output box listed fictional `fingerprint.json` + `results.html` artifacts | Replaced with real write set |
| `docs/quickstart.md` | Flowchart output node only mentioned `results.csv` | Added `features.parquet` (the canonical v0.2+ artifact) |
| `docs/field-guide.md` | Same as quickstart | Same fix |

## What I deliberately did not touch

- **`paper/figure1_architecture.mmd` + `figure2_pipeline.mmd`** — already accurate to v0.5.0 (updated in PR #150).
- **README mermaid** — already accurate to v0.5.0 (updated in PR #150).
- **`docs/architecture/adr-002-bbox-roi.md`, `adr-003-climate-interpolation.md`, `adr-005-kriging-interpolation.md`** — ADRs are historical snapshots of decisions made at a point in time; the diagrams are scoped to each decision's context. Retroactively updating them would falsify the record.
- **`docs/contributing.md` mermaid** — generic Git PR workflow, independent of code state.

## Verify

- [x] `mkdocs build --strict` — clean
- [x] `pytest -q` — 300 passed, 1 skipped
- [x] No code changes