### PR TITLE
docs: purge Export + GeoAI mentions from issue template + SUPPORT.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,10 +44,12 @@ body:
       multiple: true
       options:
         - Pipeline (terraflow run)
+        - Climate-impact (temporal_aggregations + scenarios, climate_features.parquet)
+        - Hazard indicators (GDD / frost / heat / SPEI)
+        - CMIP6 NetCDF ingest (terraflow.cmip6, [cmip6] extra)
         - Sensitivity (terraflow sensitivity)
         - Validation (terraflow validate)
-        - Export (terraflow export)
-        - GeoAI engine (terraflow geoai)
+        - Kriging / climate interpolation
         - Configuration / Pydantic schema
         - Reproducibility / fingerprinting
         - Docs / paper

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -10,7 +10,7 @@ you're trying to do.
   reproducibility page, architecture decision records.
 - **Notebooks:** end-to-end examples under
   [`docs/notebooks/`](../docs/notebooks/) (climate pipeline, kriging
-  uncertainty, sensitivity, validation, H3 export, GeoAI engine).
+  uncertainty, sensitivity, validation, climate-impact crop suitability).
 - **CHANGELOG:** [`CHANGELOG.md`](../CHANGELOG.md) — what shipped in each
   release, including breaking changes.
 


### PR DESCRIPTION
Two more stale removed-feature references found in files I hadn't previously checked:

1. `.github/ISSUE_TEMPLATE/feature_request.yml` — 'Export (terraflow export)' and 'GeoAI engine (terraflow geoai)' listed in the 'Which subsystem' dropdown. A user opening a feature request would see broken options. Replaced with the current v0.5.0 subsystem list.

2. `.github/SUPPORT.md` notebooks list mentioned 'H3 export, GeoAI engine' in the parenthetical. Those notebooks no longer exist. Replaced with 'climate-impact crop suitability' (notebook 07).