### PR TITLE
feat(drought): impact-labeled drought-loss prediction benchmark (terraflow.drought)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **Drought-impact prediction benchmark (`terraflow.drought`).** A new in-package sub-package and
+  `terraflow drought {fetch,build,evaluate}` CLI that assembles and evaluates an *impact-labeled*
+  drought benchmark: predict **insured drought loss** (USDA RMA Cause of Loss, public 1989-present)
+  from within-season climate/vegetation anomalies. This is a decision-relevant *impact* target,
+  distinct from drought *severity* (USDM D2+) and crop *yield* benchmarks (CY-Bench / SustainBench).
+  - `rma.py` downloads + parses the pipe-delimited Cause of Loss files (verified 30-field layout) and
+    joins on 5-digit `GEOID`; `labels.py` builds per-(county, crop-year) `drought_loss_ratio`
+    (regression) + `significant_drought_loss` (binary), with `drought_share` as a bounded auxiliary
+    target; `predictors.py` aggregates the 30 deseasonalized flashdry `*_anom` features + USDM
+    severity up to a configurable `cutoff_doy` (early-warning framing); `splits.py` provides temporal
+    (held-out years incl. the 2012 extreme), leave-one-state-out spatial, and LOYO regimes;
+    `baselines.py`/`evaluate.py` produce a leaderboard (naive, severity-only, and Ridge/RF/GBM climate
+    models) with regression (R2/RMSE/Spearman) and classification (ROC-AUC/PR-AUC/Brier) metrics;
+    `dataset.py` writes `benchmark.parquet` + `manifest.json` (deterministic build fingerprint via
+    `terraflow.core.run_identity`) + `splits.json`.
+  - Reproducible one-shot: `terraflow drought fetch` -> `build -c cfg.yml` -> `evaluate -c cfg.yml`.
+    Sample config in `examples/drought_v0_corn_6state.yml`; provenance in `data/drought/README.md`.
+  - No new runtime dependency (reuses the existing scikit-learn / pandas / pyarrow stack). 23 new
+    tests (`tests/test_drought_*.py`); existing CLI commands are unaffected (backward-compat guard).
+
+
 ## [0.5.0] — 2026-06-30
 
 **Flagship release**: climate-impact assessment of agricultural suitability. Multi-scenario climate driver (historical + CMIP6 SSP windows) cross-multiplied with seven hazard indicators (annual mean, seasonal mean, growing-degree days, frost days, heat-stress days, precipitation percentiles, simplified Thornthwaite SPEI) lands as a sibling `climate_features.parquet` artifact alongside the historical `features.parquet`. GeoAI and H3 export modules were cut to refocus the surface on Methods-section-citable functionality (issues #134/#135/#136). See `docs/migration-v0.4-to-v0.5.md` for the full diff.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -53,3 +53,12 @@ references:
         given-names: Gnaneswara
       - family-names: Bayina
         given-names: Chandhini
+  - type: dataset
+    title: "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for the US Corn Belt"
+    doi: 10.5281/zenodo.21208651
+    year: 2026
+    authors:
+      - family-names: Marupilla
+        given-names: Gnaneswara
+      - family-names: Bayina
+        given-names: Chandhini

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -43,3 +43,13 @@ authors:
     given-names: Chandhini
     orcid: "https://orcid.org/0009-0002-1359-1762"
     affiliation: "University of Central Missouri, Missouri, United States"
+references:
+  - type: software
+    title: "flashdry: flash-drought crop-stress detection and predictor corpus"
+    repository-code: "https://github.com/gmarupilla/flashdry"
+    notes: "Predictor corpus reused (data + citation only) by the terraflow.drought benchmark."
+    authors:
+      - family-names: Marupilla
+        given-names: Gnaneswara
+      - family-names: Bayina
+        given-names: Chandhini

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PRE_COMMIT = .venv/bin/pre-commit
 MYPY = .venv/bin/mypy
 PIP_LICENSES = .venv/bin/pip-licenses
 
-.PHONY: help venv install dev test test-cov smoke-test typecheck license-check run build clean docker-build docker-run docker-smoke lint lint-fix pre-commit docs-serve docs-build paper get-demo-data
+.PHONY: help venv install dev test test-cov smoke-test typecheck license-check run build clean docker-build docker-run docker-smoke lint lint-fix pre-commit docs-serve docs-build paper get-demo-data get-drought-data drought-eval
 
 help:
 	@echo "Available commands:"
@@ -66,6 +66,14 @@ license-check:
 
 run-demo:
 	$(PYTHON) -m terraflow.cli --config examples/demo_config.yml
+
+get-drought-data:
+	@echo "Downloading RMA Cause of Loss (public) 2000-2023 into data/drought/rma ..."
+	$(PYTHON) -m terraflow.cli drought fetch --rma-dir data/drought/rma --year-min 2000 --year-max 2023
+
+drought-eval:
+	$(PYTHON) -m terraflow.cli drought build -c examples/drought_v0_corn_6state.yml
+	$(PYTHON) -m terraflow.cli drought evaluate -c examples/drought_v0_corn_6state.yml
 
 # ---------------------------
 # Build & Release

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ flowchart LR
 
 ---
 
+## Drought-impact prediction benchmark
+
+`terraflow drought` builds and evaluates an **impact-labeled** drought benchmark — predicting
+**insured drought loss** (USDA RMA Cause of Loss) from within-season climate/vegetation anomalies.
+It is a decision-relevant *impact* target, distinct from drought *severity* (USDM D2+) and crop
+*yield* benchmarks (CY-Bench, SustainBench).
+
+```bash
+terraflow drought fetch    --rma-dir data/drought/rma --year-min 2000 --year-max 2023
+terraflow drought build    -c examples/drought_v0_corn_6state.yml
+terraflow drought evaluate -c examples/drought_v0_corn_6state.yml
+```
+
+See the [drought benchmark guide](https://terraflow.marupilla.dev/guides/drought-benchmark/).
+
+---
+
 ## Installation
 
 **macOS (Homebrew)** — handles GDAL and PROJ automatically:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ terraflow drought build    -c examples/drought_v0_corn_6state.yml
 terraflow drought evaluate -c examples/drought_v0_corn_6state.yml
 ```
 
-See the [drought benchmark guide](https://terraflow.marupilla.dev/guides/drought-benchmark/).
+Dataset on Zenodo: **[10.5281/zenodo.21208651](https://doi.org/10.5281/zenodo.21208651)** (CC-BY-4.0). See the [drought benchmark guide](https://terraflow.marupilla.dev/guides/drought-benchmark/).
 
 ---
 

--- a/data/drought/.gitignore
+++ b/data/drought/.gitignore
@@ -1,0 +1,4 @@
+# Keep the benchmark data out of git; track only the provenance docs.
+*
+!.gitignore
+!README.md

--- a/data/drought/.gitignore
+++ b/data/drought/.gitignore
@@ -1,4 +1,6 @@
-# Keep the benchmark data out of git; track only the provenance docs.
+# Keep the benchmark data out of git; track only the provenance/metadata docs.
 *
 !.gitignore
 !README.md
+!DATASHEET.md
+!zenodo-benchmark.json

--- a/data/drought/DATASHEET.md
+++ b/data/drought/DATASHEET.md
@@ -45,6 +45,6 @@ leaderboard (`leaderboard.csv`) covers naive, severity-only, and Ridge/RF/GBM cl
 
 ## Distribution & license
 
-- Benchmark table + splits + manifest + leaderboard are released on Zenodo (dataset DOI; see
-  `zenodo-benchmark.json`). Code: MIT (`terraflow`). Upstream data are public/open; cite the flashdry
+- Benchmark table + splits + manifest + leaderboard are released on Zenodo:
+  **DOI [10.5281/zenodo.21208651](https://doi.org/10.5281/zenodo.21208651)** (concept DOI — always latest version). Code: MIT (`terraflow`). Upstream data are public/open; cite the flashdry
   corpus and the upstream products.

--- a/data/drought/DATASHEET.md
+++ b/data/drought/DATASHEET.md
@@ -1,0 +1,50 @@
+# Datasheet — Drought-Impact Prediction Benchmark (v0)
+
+Following Gebru et al., *Datasheets for Datasets* (2021).
+
+## Motivation
+
+- **Purpose.** Provide a prediction-ready, *impact-labeled* drought benchmark: predict realized
+  **insured drought loss** from within-season climate/vegetation signal. Existing drought benchmarks
+  target *severity* (USDM D2+) or crop *yield*; none uses drought-attributed insured loss.
+- **Who built it.** The TerraFlow authors (see `CITATION.cff`), assembled with `terraflow.drought`.
+
+## Composition
+
+- **Instances.** One row per (county `GEOID`, corn crop-year). v0 = corn, 6-state Corn Belt
+  (IL/IN/IA/MN/MO/NE), 2000–2023. **13,895 rows, 587 counties.**
+- **Features.** 30 deseasonalized flashdry climate anomalies (`*_anom`) + `NDVI_anom_z` + USDM
+  severity (`dm_gte_d2`, `dm_class`), each aggregated {mean, min, max, last} up to `cutoff_doy`
+  (default ≈ Jul 31 — early-warning), plus `n_obs` and `n_stress_weeks`.
+- **Labels.** `drought_loss_ratio` (regression), `significant_drought_loss` (binary, positive rate
+  **18.5%**), `drought_share` (bounded auxiliary), and raw `drought_indemnity` / `total_indemnity` /
+  `liability`.
+- **Splits** (`splits.json`). Temporal (train ≤ 2015, test = 2012/2017/2022/2023), leave-one-state-out
+  spatial, leave-one-year-out.
+
+## Collection process
+
+- **Labels** — USDA RMA *Cause of Loss* Summary-of-Business files (public, pipe-delimited, 1989–present).
+  Drought-attributed indemnity (`Cause of Loss Description == "Drought"`) per county-crop-year.
+- **Predictors** — the flashdry corpus (MODIS NDVI / ERA5-Land / Daymet / USDM / USDA-NASS), county-
+  aggregated. See <https://github.com/gmarupilla/flashdry>.
+- **Reproducibility** — `manifest.json` carries a SHA-256 build fingerprint over config + input hashes.
+
+## Recommended uses
+
+Drought-loss classification/regression under temporal and spatial distribution shift. Baseline
+leaderboard (`leaderboard.csv`) covers naive, severity-only, and Ridge/RF/GBM climate models.
+
+## Limitations & caveats
+
+- **Insured-acre coverage.** RMA Cause of Loss covers *insured* acres only; participation varies by
+  crop/region/year. A per-county-year coverage-bias column is a planned follow-up.
+- **Denominator.** `drought_loss_ratio` uses loss-experience liability and can exceed 1.0 in
+  catastrophic county-years — prefer **rank metrics (Spearman)** and the **binary target**.
+- **Scope.** v0 is corn + Corn Belt; soybean, CONUS, and additional predictors (e.g. GRACE) are future work.
+
+## Distribution & license
+
+- Benchmark table + splits + manifest + leaderboard are released on Zenodo (dataset DOI; see
+  `zenodo-benchmark.json`). Code: MIT (`terraflow`). Upstream data are public/open; cite the flashdry
+  corpus and the upstream products.

--- a/data/drought/README.md
+++ b/data/drought/README.md
@@ -1,0 +1,28 @@
+# Drought-impact benchmark — data provenance
+
+This directory holds inputs for the `terraflow.drought` benchmark. **No large data is committed** —
+files land here at build time (the directory is git-ignored except this README).
+
+## Label — USDA RMA Cause of Loss (public, free)
+
+- Source: <https://www.rma.usda.gov/tools-reports/summary-of-business/cause-loss>
+- Pipe-delimited flat files, one ZIP per commodity year, 1989–present (30-field record layout).
+- Fetched by `terraflow drought fetch --rma-dir data/drought/rma` into `rma/colsom_YYYY.zip`.
+- The impact label is drought-attributed insured indemnity per county-crop-year
+  (`Cause of Loss Description == "Drought"`), normalized by loss-experience liability.
+- **Known limitation:** Cause of Loss covers *insured* acres only; participation varies by
+  crop/region/year, and the loss-experience liability denominator can push `drought_loss_ratio`
+  above 1 in catastrophic county-years. Rank metrics + the binary target are the robust headlines.
+
+## Predictors — flashdry corpus (separate repo, cite; do not vendor)
+
+- Repo: <https://github.com/gmarupilla/flashdry> (own Zenodo DOI / `CITATION.cff`).
+- `feature_table.parquet` — county × growing-season climate/vegetation anomalies + USDM severity,
+  6-state Corn Belt, 2000–2023, keyed on 5-digit `GEOID`. Point `feature_table:` in the config at it.
+- Upstream sources (all public): MODIS NDVI (NASA LP DAAC), ERA5-Land (Copernicus CDS), Daymet
+  (ORNL), USDM (droughtmonitor.unl.edu), USDA-NASS QuickStats.
+
+## Reproducibility
+
+Every `terraflow drought build` writes `manifest.json` with a SHA-256 build fingerprint over the
+config + input file hashes, so identical inputs reproduce a byte-identical benchmark table.

--- a/data/drought/zenodo-benchmark.json
+++ b/data/drought/zenodo-benchmark.json
@@ -1,0 +1,21 @@
+{
+  "//": "Metadata for the MANUAL Zenodo dataset deposit of the drought-impact benchmark. This is NOT the flashdry GitHub-release integration; upload the bundled artifacts (benchmark.parquet, splits.json, manifest.json, leaderboard.csv, evaluate_report.json, DATASHEET.md) as a new Zenodo record and paste these fields.",
+  "title": "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for the US Corn Belt",
+  "upload_type": "dataset",
+  "description": "A prediction-ready, impact-labeled drought benchmark: predict realized insured drought loss (USDA RMA Cause of Loss) from within-season climate/vegetation anomalies. v0 covers corn across the 6-state US Corn Belt (IL/IN/IA/MN/MO/NE), 2000-2023 (13,895 county-years, 587 counties, 18.5% positive). Distinct from drought-severity (USDM) and crop-yield benchmarks. Includes official temporal / leave-one-state-out spatial / leave-one-year-out splits and a baseline leaderboard. Built and reproducible with the open-source terraflow.drought pipeline.",
+  "creators": [
+    {"name": "Marupilla, Gnaneswara", "orcid": "0000-0002-6030-8707"},
+    {"name": "Bayina, Chandhini", "orcid": "0009-0002-1359-1762", "affiliation": "University of Central Missouri"}
+  ],
+  "keywords": [
+    "drought", "agriculture", "crop insurance", "impact prediction", "benchmark",
+    "remote sensing", "climate", "Corn Belt", "machine learning", "reproducibility"
+  ],
+  "license": "cc-by-4.0",
+  "related_identifiers": [
+    {"relation": "isDerivedFrom", "identifier": "https://github.com/gmarupilla/flashdry", "resource_type": "software"},
+    {"relation": "isSupplementTo", "identifier": "https://github.com/gmarupilla/AgroTerraFlow", "resource_type": "software"},
+    {"relation": "references", "identifier": "https://www.rma.usda.gov/tools-reports/summary-of-business/cause-loss", "resource_type": "dataset"}
+  ],
+  "notes": "Predictors derive from the flashdry corpus (MODIS/ERA5-Land/Daymet/USDM/USDA-NASS); labels from public USDA RMA Cause of Loss. See DATASHEET.md for full provenance and limitations."
+}

--- a/data/drought/zenodo-benchmark.json
+++ b/data/drought/zenodo-benchmark.json
@@ -1,5 +1,7 @@
 {
   "//": "Metadata for the MANUAL Zenodo dataset deposit of the drought-impact benchmark. This is NOT the flashdry GitHub-release integration; upload the bundled artifacts (benchmark.parquet, splits.json, manifest.json, leaderboard.csv, evaluate_report.json, DATASHEET.md) as a new Zenodo record and paste these fields.",
+  "doi": "10.5281/zenodo.21208651",
+  "version_doi": "10.5281/zenodo.21208652",
   "title": "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for the US Corn Belt",
   "upload_type": "dataset",
   "description": "A prediction-ready, impact-labeled drought benchmark: predict realized insured drought loss (USDA RMA Cause of Loss) from within-season climate/vegetation anomalies. v0 covers corn across the 6-state US Corn Belt (IL/IN/IA/MN/MO/NE), 2000-2023 (13,895 county-years, 587 counties, 18.5% positive). Distinct from drought-severity (USDM) and crop-yield benchmarks. Includes official temporal / leave-one-state-out spatial / leave-one-year-out splits and a baseline leaderboard. Built and reproducible with the open-source terraflow.drought pipeline.",

--- a/docs/api/drought.md
+++ b/docs/api/drought.md
@@ -1,0 +1,48 @@
+---
+title: Drought Benchmark API
+description: API reference for terraflow.drought — the impact-labeled drought-loss prediction benchmark.
+icon: material/water-alert
+tags:
+  - API
+  - Reference
+---
+
+# terraflow.drought
+
+Impact-labeled drought-loss prediction benchmark. Predicts insured drought loss (USDA RMA Cause of
+Loss) from within-season climate/vegetation anomalies. See the
+[Drought benchmark guide](../guides/drought-benchmark.md) for the task, splits, and reference results.
+
+## Configuration
+
+::: terraflow.drought.config
+
+## RMA Cause of Loss ingest
+
+::: terraflow.drought.rma
+
+## Labels
+
+::: terraflow.drought.labels
+
+## Predictors
+
+::: terraflow.drought.predictors
+
+## Splits
+
+::: terraflow.drought.splits
+
+## Dataset assembly
+
+::: terraflow.drought.dataset
+
+## Baselines & metrics
+
+::: terraflow.drought.baselines
+
+::: terraflow.drought.metrics
+
+## Evaluation
+
+::: terraflow.drought.evaluate

--- a/docs/guides/drought-benchmark.md
+++ b/docs/guides/drought-benchmark.md
@@ -1,0 +1,66 @@
+# Drought-impact prediction benchmark
+
+`terraflow.drought` assembles and evaluates an **impact-labeled** drought benchmark: predict
+**insured drought loss** from within-season climate and vegetation signal. The label is USDA RMA
+*Cause of Loss* indemnity attributed to drought — a decision-relevant economic *impact* target,
+distinct from drought *severity* (USDM D2+) and crop *yield* benchmarks (CY-Bench, SustainBench).
+
+## Why this benchmark
+
+Existing drought benchmarks predict how *dry* it is (severity) or how much a crop *yields*. Neither
+answers the question insurers, agencies, and adaptation planners actually face: **where will drought
+translate into realized loss this season?** RMA Cause of Loss is the public, county-level record of
+that realized loss, back to 1989 — but it has never been packaged as a prediction-ready ML benchmark.
+
+## Task
+
+- **Unit:** (county `GEOID`, crop-year), corn, 6-state Corn Belt (IL/IN/IA/MN/MO/NE), 2000–2023.
+- **Targets:** `drought_loss_ratio` (regression) and `significant_drought_loss` (binary), plus a
+  bounded `drought_share` auxiliary.
+- **Predictors:** the 30 deseasonalized flashdry `*_anom` climate features + `NDVI_anom_z` + USDM
+  severity, aggregated {mean, min, max, last} up to `cutoff_doy` (default ≈ Jul 31) — an
+  **early-warning** framing (predict end-of-season loss from mid-season signal).
+- **Splits:** temporal (held-out years incl. the 2012 extreme + recent 2022/2023), leave-one-state-out
+  spatial, and leave-one-year-out.
+
+## Quickstart
+
+```bash
+terraflow drought fetch    --rma-dir data/drought/rma --year-min 2000 --year-max 2023
+terraflow drought build    -c examples/drought_v0_corn_6state.yml
+terraflow drought evaluate -c examples/drought_v0_corn_6state.yml
+```
+
+`build` writes `benchmark.parquet` + `manifest.json` (deterministic build fingerprint) + `splits.json`;
+`evaluate` writes `evaluate_report.json` + `leaderboard.csv`.
+
+## Reference results (v0, 587 counties, 13,895 county-years, 18.5% positive)
+
+Temporal split (train ≤ 2015, test = 2012/2017/2022/2023):
+
+| Task | Model | Headline |
+|---|---|---|
+| Classification | LogReg [climate] | ROC-AUC **0.93**, PR-AUC **0.78** |
+| Classification | LogReg [severity] | ROC-AUC 0.92, PR-AUC 0.73 |
+| Classification | RandomForest [climate] | ROC-AUC 0.27 (temporal extrapolation collapse) |
+| Regression | Ridge [climate] | Spearman **0.65** |
+| Spatial LOSO | RandomForest [climate] | mean ROC-AUC **0.91** |
+
+Findings: (1) within-season signal predicts insured drought loss well (AUC ≈ 0.91–0.93);
+(2) USDM severity is a *strong* baseline — within-season climate anomalies match/slightly beat it and
+are available earlier in the season; (3) **temporal extrapolation to extreme years is the open
+challenge** — tree models collapse under distribution shift while linear models hold. That model-class
+gap is the benchmark's most interesting result.
+
+## Limitations (datasheet notes)
+
+- RMA Cause of Loss covers **insured acres only**; participation varies by crop/region/year.
+- The loss-experience liability denominator can push `drought_loss_ratio` above 1 in catastrophic
+  years — prefer rank metrics (Spearman) and the binary target.
+- v0 is corn + Corn Belt; soybean, CONUS, and a coverage-bias column are planned follow-ups.
+
+## Provenance & citation
+
+The predictor corpus comes from the separate [flashdry](https://github.com/gmarupilla/flashdry) repo
+(cite its Zenodo DOI; not vendored here). See `data/drought/README.md` for upstream sources and
+licenses.

--- a/docs/guides/drought-benchmark.md
+++ b/docs/guides/drought-benchmark.md
@@ -5,6 +5,8 @@
 *Cause of Loss* indemnity attributed to drought — a decision-relevant economic *impact* target,
 distinct from drought *severity* (USDM D2+) and crop *yield* benchmarks (CY-Bench, SustainBench).
 
+**Dataset:** Zenodo DOI [10.5281/zenodo.21208651](https://doi.org/10.5281/zenodo.21208651) (CC-BY-4.0).
+
 ## Why this benchmark
 
 Existing drought benchmarks predict how *dry* it is (severity) or how much a crop *yields*. Neither

--- a/docs/notebooks/08_drought_impact_benchmark.ipynb
+++ b/docs/notebooks/08_drought_impact_benchmark.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Drought-impact prediction benchmark (`terraflow.drought`)\n",
+    "\n",
+    "Predict **insured drought loss** (USDA RMA Cause of Loss) from within-season climate/vegetation\n",
+    "anomalies \u2014 a decision-relevant *impact* target, distinct from drought *severity* (USDM D2+) and\n",
+    "crop *yield* benchmarks. This notebook walks the fetch \u2192 build \u2192 evaluate workflow.\n",
+    "\n",
+    "See the [guide](https://terraflow.marupilla.dev/guides/drought-benchmark/) for task details.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Point `feature_table` at the flashdry `feature_table.parquet` and `rma_dir` where the RMA\n",
+    "Cause of Loss ZIPs live (fetch them with `terraflow drought fetch`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.config import DroughtConfig\n",
+    "\n",
+    "cfg = DroughtConfig(\n",
+    "    states=['17', '18', '19', '27', '29', '31'],  # 6-state Corn Belt\n",
+    "    crop='CORN', year_min=2000, year_max=2023,\n",
+    "    cutoff_doy=212,                # early-warning: signal available by ~Jul 31\n",
+    "    test_years=[2012, 2017, 2022, 2023], train_max_year=2015,\n",
+    "    rma_dir='data/drought/rma',\n",
+    "    feature_table='PATH/TO/flashdry/data/processed/feature_table.parquet',\n",
+    "    output_dir='outputs/drought_v0',\n",
+    ")\n",
+    "cfg.years[:5], cfg.years[-3:]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Build the benchmark table\n",
+    "\n",
+    "Parses RMA Cause of Loss \u2192 drought-loss labels, aggregates predictors up to the cutoff, and\n",
+    "joins them into `benchmark.parquet` with a deterministic build fingerprint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.dataset import assemble_benchmark\n",
+    "\n",
+    "benchmark = assemble_benchmark(cfg, write=True)\n",
+    "print(len(benchmark), 'county-years;', benchmark.GEOID.nunique(), 'counties')\n",
+    "print('positive rate:', round(benchmark.significant_drought_loss.mean(), 3))\n",
+    "benchmark[['GEOID', 'year', 'drought_loss_ratio', 'significant_drought_loss']].head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Evaluate the leaderboard\n",
+    "\n",
+    "Naive, severity-only, and Ridge/RF/GBM climate models across the temporal and spatial regimes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.evaluate import run_leaderboard\n",
+    "\n",
+    "report = run_leaderboard(benchmark, cfg, write_dir=cfg.output_dir)\n",
+    "for model, m in report['temporal']['classification'].items():\n",
+    "    print(f\"{model:26s} ROC-AUC={m['roc_auc']:.3f}  PR-AUC={m['pr_auc']:.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Findings (v0)\n",
+    "\n",
+    "- Within-season signal predicts insured drought loss well (ROC-AUC ~0.91-0.93).\n",
+    "- USDM severity is a strong baseline; climate anomalies match/slightly beat it **and arrive earlier**.\n",
+    "- Temporal extrapolation to extreme years (2012) is the hard regime: tree models collapse while\n",
+    "  linear models hold \u2014 the benchmark's most interesting open challenge.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/drought_v0_corn_6state.yml
+++ b/examples/drought_v0_corn_6state.yml
@@ -1,0 +1,31 @@
+# Drought-impact benchmark — v0 (corn, 6-state Corn Belt).
+#
+# Predicts insured drought loss (USDA RMA Cause of Loss) from within-season climate/vegetation
+# anomalies. Edit the three paths below, then:
+#
+#   terraflow drought fetch --rma-dir data/drought/rma --year-min 2000 --year-max 2023
+#   terraflow drought build    -c examples/drought_v0_corn_6state.yml
+#   terraflow drought evaluate -c examples/drought_v0_corn_6state.yml
+
+# Spatial / temporal scope
+states: ["17", "18", "19", "27", "29", "31"]   # IL IN IA MN MO NE (FIPS state codes)
+crop: "CORN"
+year_min: 2000
+year_max: 2023
+
+# Label (RMA Cause of Loss)
+drought_causes: ["Drought"]       # add "Heat", "Hot Wind" for a heat-inclusive variant
+loss_ratio_threshold: 0.10        # binary "significant drought loss" cutoff on drought_loss_ratio
+
+# Predictor aggregation
+cutoff_doy: 212                   # ~Jul 31 — early-warning framing; 273 = end-of-season variant
+
+# Splits
+test_years: [2012, 2017, 2022, 2023]
+train_max_year: 2015
+n_blocks_side: 4
+
+# Paths (edit these)
+rma_dir: "data/drought/rma"                       # where `terraflow drought fetch` writes colsom_*.zip
+feature_table: "PATH/TO/flashdry/data/processed/feature_table.parquet"
+output_dir: "outputs/drought_v0"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,6 +163,7 @@ nav:
       - terraflow.stats: api/stats.md
       - terraflow.sensitivity: api/sensitivity.md
       - terraflow.validation: api/validation.md
+      - terraflow.drought: api/drought.md
   - Notebooks:
       - TerraFlow v0.2.0 Demo: notebooks/terraflow_v0_2_0_comprehensive_test.ipynb
       - Kriging and Uncertainty: notebooks/kriging_uncertainty_demo.ipynb
@@ -170,8 +171,10 @@ nav:
       - Sensitivity Analysis: notebooks/02_sensitivity_analysis.ipynb
       - Model Validation: notebooks/03_model_validation.ipynb
       - Climate-Impact Crop Suitability: notebooks/07_climate_impact_crop_suitability.ipynb
+      - Drought-Impact Benchmark: notebooks/08_drought_impact_benchmark.ipynb
   - Guides:
       - Satellite inputs: guides/satellite-inputs.md
+      - Drought benchmark: guides/drought-benchmark.md
   - Migration v0.4 → v0.5: migration-v0.4-to-v0.5.md
   - Development: DEVELOPMENT.md
   - Roadmap: ROADMAP.md

--- a/notebooks/08_drought_impact_benchmark.ipynb
+++ b/notebooks/08_drought_impact_benchmark.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Drought-impact prediction benchmark (`terraflow.drought`)\n",
+    "\n",
+    "Predict **insured drought loss** (USDA RMA Cause of Loss) from within-season climate/vegetation\n",
+    "anomalies \u2014 a decision-relevant *impact* target, distinct from drought *severity* (USDM D2+) and\n",
+    "crop *yield* benchmarks. This notebook walks the fetch \u2192 build \u2192 evaluate workflow.\n",
+    "\n",
+    "See the [guide](https://terraflow.marupilla.dev/guides/drought-benchmark/) for task details.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration\n",
+    "\n",
+    "Point `feature_table` at the flashdry `feature_table.parquet` and `rma_dir` where the RMA\n",
+    "Cause of Loss ZIPs live (fetch them with `terraflow drought fetch`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.config import DroughtConfig\n",
+    "\n",
+    "cfg = DroughtConfig(\n",
+    "    states=['17', '18', '19', '27', '29', '31'],  # 6-state Corn Belt\n",
+    "    crop='CORN', year_min=2000, year_max=2023,\n",
+    "    cutoff_doy=212,                # early-warning: signal available by ~Jul 31\n",
+    "    test_years=[2012, 2017, 2022, 2023], train_max_year=2015,\n",
+    "    rma_dir='data/drought/rma',\n",
+    "    feature_table='PATH/TO/flashdry/data/processed/feature_table.parquet',\n",
+    "    output_dir='outputs/drought_v0',\n",
+    ")\n",
+    "cfg.years[:5], cfg.years[-3:]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Build the benchmark table\n",
+    "\n",
+    "Parses RMA Cause of Loss \u2192 drought-loss labels, aggregates predictors up to the cutoff, and\n",
+    "joins them into `benchmark.parquet` with a deterministic build fingerprint.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.dataset import assemble_benchmark\n",
+    "\n",
+    "benchmark = assemble_benchmark(cfg, write=True)\n",
+    "print(len(benchmark), 'county-years;', benchmark.GEOID.nunique(), 'counties')\n",
+    "print('positive rate:', round(benchmark.significant_drought_loss.mean(), 3))\n",
+    "benchmark[['GEOID', 'year', 'drought_loss_ratio', 'significant_drought_loss']].head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Evaluate the leaderboard\n",
+    "\n",
+    "Naive, severity-only, and Ridge/RF/GBM climate models across the temporal and spatial regimes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from terraflow.drought.evaluate import run_leaderboard\n",
+    "\n",
+    "report = run_leaderboard(benchmark, cfg, write_dir=cfg.output_dir)\n",
+    "for model, m in report['temporal']['classification'].items():\n",
+    "    print(f\"{model:26s} ROC-AUC={m['roc_auc']:.3f}  PR-AUC={m['pr_auc']:.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Findings (v0)\n",
+    "\n",
+    "- Within-season signal predicts insured drought loss well (ROC-AUC ~0.91-0.93).\n",
+    "- USDM severity is a strong baseline; climate anomalies match/slightly beat it **and arrive earlier**.\n",
+    "- Temporal extrapolation to extreme years (2012) is the hard regime: tree models collapse while\n",
+    "  linear models hold \u2014 the benchmark's most interesting open challenge.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ Homepage = "https://github.com/gmarupilla/AgroTerraFlow"
 Documentation = "https://terraflow.marupilla.dev"
 
 [tool.setuptools]
-packages = ["terraflow", "terraflow.core"]
+packages = ["terraflow", "terraflow.core", "terraflow.drought"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/terraflow/cli.py
+++ b/terraflow/cli.py
@@ -17,6 +17,10 @@ app = typer.Typer(
     add_completion=False,
 )
 
+from .drought.cli import drought_app  # noqa: E402 (registered after app is created)
+
+app.add_typer(drought_app, name="drought")
+
 
 def _config_option() -> Any:
     return typer.Option(

--- a/terraflow/drought/__init__.py
+++ b/terraflow/drought/__init__.py
@@ -1,0 +1,20 @@
+"""terraflow.drought — impact-labeled drought-loss prediction benchmark.
+
+Predicts *insured drought loss* (USDA RMA Cause of Loss) from within-season climate/vegetation
+predictors — a decision-relevant impact target distinct from drought *severity* (USDM D2+) and
+crop *yield* benchmarks.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "baselines",
+    "config",
+    "dataset",
+    "evaluate",
+    "labels",
+    "metrics",
+    "predictors",
+    "rma",
+    "splits",
+]

--- a/terraflow/drought/baselines.py
+++ b/terraflow/drought/baselines.py
@@ -1,0 +1,89 @@
+"""Baseline models for the drought-impact benchmark.
+
+Three tiers, to make the leaderboard interpretable:
+- **naive** — constant train mean, and per-county historical mean (the bar any model must beat).
+- **severity-only** — a model on the USDM severity aggregates alone. USDM D2+ is a *strong*
+  baseline for loss; the point of isolating it is to quantify how much within-season climate signal
+  adds on top (and that it is available earlier in the season for early warning).
+- **climate ML** — Ridge / RandomForest / GradientBoosting on the within-season anomaly features.
+
+All estimators are seeded (``random_state=0``, ``n_jobs=1``) so the leaderboard is deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import (
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+from sklearn.linear_model import LogisticRegression, Ridge
+
+from .predictors import climate_predictor_columns, severity_predictor_columns
+
+RANDOM_STATE = 0
+REGRESSION_TARGET = "drought_loss_ratio"
+CLASSIFICATION_TARGET = "significant_drought_loss"
+
+
+def feature_columns(which: str) -> list[str]:
+    """Feature column names for a feature set: 'climate', 'severity', or 'all'."""
+    if which == "climate":
+        return climate_predictor_columns() + ["n_obs", "n_stress_weeks"]
+    if which == "severity":
+        return severity_predictor_columns()
+    if which == "all":
+        return feature_columns("climate") + feature_columns("severity")
+    raise ValueError(f"Unknown feature set: {which!r}")
+
+
+def feature_matrix(df: pd.DataFrame, which: str) -> np.ndarray:
+    """Numeric feature matrix (NaN → 0.0; anomalies are z-scores, so 0 is neutral)."""
+    cols = feature_columns(which)
+    return df[cols].to_numpy(dtype=float, na_value=0.0)
+
+
+def make_regressors() -> dict[str, Any]:
+    return {
+        "Ridge": Ridge(alpha=1.0),
+        "RandomForest": RandomForestRegressor(n_estimators=200, random_state=RANDOM_STATE, n_jobs=1),
+        "GradientBoost": GradientBoostingRegressor(random_state=RANDOM_STATE),
+    }
+
+
+def make_classifiers() -> dict[str, Any]:
+    return {
+        "LogReg": LogisticRegression(max_iter=1000),
+        "RandomForest": RandomForestClassifier(
+            n_estimators=200, random_state=RANDOM_STATE, n_jobs=1, class_weight="balanced"
+        ),
+        "GradientBoost": GradientBoostingClassifier(random_state=RANDOM_STATE),
+    }
+
+
+class MeanBaseline:
+    """Predict the constant training mean of the target."""
+
+    def fit(self, df_train: pd.DataFrame, target: str) -> "MeanBaseline":
+        self.value_ = float(df_train[target].astype(float).mean())
+        return self
+
+    def predict(self, df_test: pd.DataFrame) -> np.ndarray:
+        return np.full(len(df_test), self.value_, dtype=float)
+
+
+class CountyHistoryBaseline:
+    """Predict each county's historical (training) mean target, falling back to the global mean."""
+
+    def fit(self, df_train: pd.DataFrame, target: str) -> "CountyHistoryBaseline":
+        self.global_ = float(df_train[target].astype(float).mean())
+        self.by_county_ = df_train.groupby("GEOID")[target].mean().astype(float).to_dict()
+        return self
+
+    def predict(self, df_test: pd.DataFrame) -> np.ndarray:
+        return df_test["GEOID"].map(self.by_county_).fillna(self.global_).to_numpy(dtype=float)

--- a/terraflow/drought/cli.py
+++ b/terraflow/drought/cli.py
@@ -1,0 +1,65 @@
+"""Typer sub-app for the drought-impact benchmark: ``terraflow drought {fetch,build,evaluate}``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ..utils import logger
+from .config import DroughtConfig
+from .dataset import assemble_benchmark, load_benchmark
+from .evaluate import run_leaderboard
+from .rma import download_col_years
+
+drought_app = typer.Typer(
+    name="drought",
+    help="Impact-labeled drought-loss prediction benchmark (RMA Cause of Loss).",
+    add_completion=False,
+)
+
+_ConfigOpt = Annotated[
+    Path,
+    typer.Option("--config", "-c", exists=True, dir_okay=False, readable=True, help="Benchmark YAML config"),
+]
+
+
+@drought_app.command("fetch")
+def fetch_cmd(
+    rma_dir: Annotated[Path, typer.Option(help="Directory to store RMA Cause of Loss ZIPs")],
+    year_min: Annotated[int, typer.Option(help="First commodity year")] = 2000,
+    year_max: Annotated[int, typer.Option(help="Last commodity year")] = 2023,
+    overwrite: Annotated[bool, typer.Option(help="Re-download existing files")] = False,
+) -> None:
+    """Download RMA Cause of Loss files for a year range."""
+    years = list(range(year_min, year_max + 1))
+    logger.info(f"Fetching RMA Cause of Loss {year_min}-{year_max} into {rma_dir}")
+    paths = download_col_years(years, rma_dir, overwrite=overwrite)
+    logger.info(f"Fetched {len(paths)} files.")
+
+
+@drought_app.command("build")
+def build_cmd(config: _ConfigOpt) -> None:
+    """Assemble the benchmark table + manifest + splits from a config."""
+    cfg = DroughtConfig.from_yaml(config)
+    logger.info(f"Building drought benchmark → {cfg.output_dir}")
+    benchmark = assemble_benchmark(cfg, write=True)
+    logger.info(
+        f"Built {len(benchmark)} rows over {benchmark['GEOID'].nunique()} counties; "
+        f"positive rate {benchmark['significant_drought_loss'].mean():.3f}"
+    )
+
+
+@drought_app.command("evaluate")
+def evaluate_cmd(config: _ConfigOpt) -> None:
+    """Run the leaderboard on a previously built benchmark."""
+    cfg = DroughtConfig.from_yaml(config)
+    benchmark = load_benchmark(cfg.output_dir)
+    report = run_leaderboard(benchmark, cfg, write_dir=cfg.output_dir)
+    top = report["temporal"]["classification"]
+    logger.info("Leaderboard (temporal split) written. Classification PR-AUC by model:")
+    for model, m in top.items():
+        print(f"  {model:28s} PR-AUC={m['pr_auc']:.3f}  ROC-AUC={m['roc_auc']:.3f}")
+    print(json.dumps(report["counts"], indent=2))

--- a/terraflow/drought/config.py
+++ b/terraflow/drought/config.py
@@ -1,0 +1,72 @@
+"""Configuration model for the drought-impact benchmark.
+
+The benchmark predicts *insured drought loss* (USDA RMA Cause of Loss) from within-season
+climate/vegetation predictors. This module defines the single Pydantic config that drives the
+whole build so runs are reproducible and fingerprintable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+# The 6-state Corn Belt used by the flashdry predictor corpus (FIPS state codes).
+CORN_BELT_STATES: tuple[str, ...] = ("17", "18", "19", "27", "29", "31")  # IL IN IA MN MO NE
+
+
+class DroughtConfig(BaseModel):
+    """End-to-end configuration for building and evaluating the drought-impact benchmark."""
+
+    # --- Spatial / temporal scope -------------------------------------------------------
+    states: list[str] = Field(default_factory=lambda: list(CORN_BELT_STATES))
+    crop: str = "CORN"
+    year_min: int = 2000
+    year_max: int = 2023
+
+    # --- Label definition (RMA Cause of Loss) -------------------------------------------
+    # Cause-of-loss *descriptions* (field 13) counted as drought-attributed. "Drought" is the
+    # clean, defensible default; ``["Drought", "Heat", "Hot Wind"]`` gives a heat-inclusive variant.
+    drought_causes: list[str] = Field(default_factory=lambda: ["Drought"])
+    # Binary "significant drought loss" threshold on the primary regression target
+    # (drought_loss_ratio = drought_indemnity / liability).
+    loss_ratio_threshold: float = 0.10
+
+    # --- Predictor aggregation ----------------------------------------------------------
+    # Aggregate within-season predictors only up to this day-of-year (early-warning framing).
+    # 212 ≈ Jul 31. Set to 273 (Sep 30) for the end-of-season variant.
+    cutoff_doy: int = 212
+
+    # --- Splits -------------------------------------------------------------------------
+    test_years: list[int] = Field(default_factory=lambda: [2012, 2017, 2022, 2023])
+    train_max_year: int = 2015
+    n_blocks_side: int = 4  # spatial-block grid is n×n
+
+    # --- Paths --------------------------------------------------------------------------
+    rma_dir: Path  # directory holding colsom_YYYY.txt (or .zip) files
+    feature_table: Path  # flashdry data/processed/feature_table.parquet
+    output_dir: Path
+
+    @field_validator("states", mode="before")
+    @classmethod
+    def _pad_states(cls, v: list[str]) -> list[str]:
+        return [str(s).zfill(2) for s in v]
+
+    @field_validator("year_max")
+    @classmethod
+    def _years_ordered(cls, v: int, info) -> int:
+        ymin = info.data.get("year_min")
+        if ymin is not None and v < ymin:
+            raise ValueError(f"year_max ({v}) must be >= year_min ({ymin})")
+        return v
+
+    @property
+    def years(self) -> list[int]:
+        return list(range(self.year_min, self.year_max + 1))
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "DroughtConfig":
+        """Load a :class:`DroughtConfig` from a YAML file."""
+        data = yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+        return cls(**data)

--- a/terraflow/drought/dataset.py
+++ b/terraflow/drought/dataset.py
@@ -1,0 +1,110 @@
+"""Assemble the drought-impact benchmark table and load it back.
+
+Pipeline: parse RMA Cause of Loss → build labels → aggregate flashdry predictors → LEFT-join
+predictors ⋈ labels on (GEOID, year). County-years present in the predictor panel but absent from
+Cause of Loss are genuine *insured-loss negatives* (drought_loss_ratio = 0, not significant), so
+they are retained and filled — this both completes the panel and provides the negative class.
+
+Writes ``benchmark.parquet`` + ``manifest.json`` (config snapshot + input fingerprints + a
+deterministic build fingerprint) + ``splits.json``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from ..core.run_identity import canonicalize_config, fingerprint_file
+from .config import DroughtConfig
+from .labels import build_labels
+from .predictors import aggregate_predictors
+from .rma import load_col
+from .splits import describe_splits
+
+_LABEL_FILL = {
+    "drought_indemnity": 0.0,
+    "total_indemnity": 0.0,
+    "liability": 0.0,
+    "drought_share": 0.0,
+    "drought_loss_ratio": 0.0,
+    "significant_drought_loss": False,
+}
+
+
+def assemble_benchmark(cfg: DroughtConfig, *, write: bool = True) -> pd.DataFrame:
+    """Build the benchmark table (and, by default, persist artifacts under ``cfg.output_dir``)."""
+    col = load_col(cfg.rma_dir, cfg.years, states=cfg.states, commodity=cfg.crop)
+    labels = build_labels(col, cfg)
+
+    feature_table = pd.read_parquet(cfg.feature_table)
+    feature_table["GEOID"] = feature_table["GEOID"].astype(str)
+    predictors = aggregate_predictors(feature_table, cfg)
+    predictors["GEOID"] = predictors["GEOID"].astype(str)
+
+    labels["GEOID"] = labels["GEOID"].astype(str)
+    benchmark = predictors.merge(labels, on=["GEOID", "year"], how="left")
+    benchmark = benchmark.fillna(_LABEL_FILL)
+    benchmark["significant_drought_loss"] = benchmark["significant_drought_loss"].astype(bool)
+    benchmark = benchmark.sort_values(["GEOID", "year"]).reset_index(drop=True)
+
+    if write:
+        _write_artifacts(benchmark, cfg, col_files=_col_paths(cfg))
+    return benchmark
+
+
+def load_benchmark(output_dir: Path) -> pd.DataFrame:
+    """Load a previously assembled ``benchmark.parquet``."""
+    path = Path(output_dir) / "benchmark.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"No benchmark at {path}; run `assemble_benchmark` first.")
+    return pd.read_parquet(path)
+
+
+def build_fingerprint(cfg: DroughtConfig, input_digests: list[dict]) -> str:
+    """Deterministic build fingerprint over the canonical config + input file digests."""
+    payload = canonicalize_config(_config_dict(cfg))
+    hasher = hashlib.sha256()
+    hasher.update(payload)
+    for d in sorted(input_digests, key=lambda x: x["path"]):
+        hasher.update(d["sha256"].encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def _config_dict(cfg: DroughtConfig) -> dict:
+    d = cfg.model_dump()
+    return {k: (str(v) if isinstance(v, Path) else v) for k, v in d.items()}
+
+
+def _col_paths(cfg: DroughtConfig) -> list[Path]:
+    out = []
+    for year in cfg.years:
+        for name in (f"colsom_{year}.zip", f"colsom{year % 100:02d}.txt", f"colsom_{year}.txt"):
+            p = Path(cfg.rma_dir) / name
+            if p.exists():
+                out.append(p)
+                break
+    return out
+
+
+def _write_artifacts(benchmark: pd.DataFrame, cfg: DroughtConfig, col_files: list[Path]) -> None:
+    out = Path(cfg.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    benchmark.to_parquet(out / "benchmark.parquet", index=False)
+
+    input_digests = [fingerprint_file(str(cfg.feature_table))]
+    input_digests += [fingerprint_file(str(p)) for p in col_files]
+    manifest = {
+        "schema_version": "1",
+        "config": _config_dict(cfg),
+        "inputs": input_digests,
+        "build_fingerprint": build_fingerprint(cfg, input_digests),
+        "n_rows": int(len(benchmark)),
+        "n_counties": int(benchmark["GEOID"].nunique()),
+        "years": [int(benchmark["year"].min()), int(benchmark["year"].max())],
+        "positive_rate": float(benchmark["significant_drought_loss"].mean()),
+    }
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    (out / "splits.json").write_text(json.dumps(describe_splits(cfg), indent=2), encoding="utf-8")

--- a/terraflow/drought/evaluate.py
+++ b/terraflow/drought/evaluate.py
@@ -10,6 +10,7 @@ Writes ``evaluate_report.json`` and ``leaderboard.csv`` to the run's output dire
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 import numpy as np
@@ -37,14 +38,19 @@ def _fit_predict_regression(name: str, feats: str, train: pd.DataFrame, test: pd
 
 
 def _fit_predict_classification(name: str, feats: str, train: pd.DataFrame, test: pd.DataFrame) -> dict:
-    est = make_classifiers()[name]
     y_train = train[CLASSIFICATION_TARGET].to_numpy(dtype=int)
+    y_test = test[CLASSIFICATION_TARGET].to_numpy(dtype=int)
+    # A one-class training set (rare-event scope / high threshold) can't fit sklearn classifiers;
+    # fall back to a constant predictor at the single observed class rather than crashing.
+    if np.unique(y_train).size < 2:
+        return classification_metrics(y_test, np.full(len(y_test), float(y_train[0]) if len(y_train) else 0.0))
+    est = make_classifiers()[name]
     est.fit(feature_matrix(train, feats), y_train)
     if hasattr(est, "predict_proba"):
         score = est.predict_proba(feature_matrix(test, feats))[:, 1]
     else:  # pragma: no cover - all configured classifiers expose predict_proba
         score = est.predict(feature_matrix(test, feats)).astype(float)
-    return classification_metrics(test[CLASSIFICATION_TARGET].to_numpy(dtype=int), score)
+    return classification_metrics(y_test, score)
 
 
 def _temporal_leaderboard(train: pd.DataFrame, test: pd.DataFrame) -> dict:
@@ -115,9 +121,20 @@ def run_leaderboard(benchmark: pd.DataFrame, cfg: DroughtConfig, *, write_dir: P
     if write_dir is not None:
         write_dir = Path(write_dir)
         write_dir.mkdir(parents=True, exist_ok=True)
-        (write_dir / "evaluate_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+        (write_dir / "evaluate_report.json").write_text(json.dumps(_json_safe(report), indent=2), encoding="utf-8")
         _leaderboard_frame(report).to_csv(write_dir / "leaderboard.csv", index=False)
     return report
+
+
+def _json_safe(obj):
+    """Recursively replace non-finite floats (NaN/inf) with None so the JSON is strict-parseable."""
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_json_safe(v) for v in obj]
+    return obj
 
 
 def _leaderboard_frame(report: dict) -> pd.DataFrame:

--- a/terraflow/drought/evaluate.py
+++ b/terraflow/drought/evaluate.py
@@ -1,0 +1,128 @@
+"""Run the drought-impact benchmark leaderboard.
+
+Headline = the official **temporal** split (train on early years, test on held-out years incl. the
+2012 extreme). Also reports a **spatial** leave-one-state-out summary for the climate models. The
+severity-only baseline is included in both to expose the severity≠impact gap.
+
+Writes ``evaluate_report.json`` and ``leaderboard.csv`` to the run's output directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .baselines import (
+    CLASSIFICATION_TARGET,
+    REGRESSION_TARGET,
+    CountyHistoryBaseline,
+    MeanBaseline,
+    feature_matrix,
+    make_classifiers,
+    make_regressors,
+)
+from .config import DroughtConfig
+from .metrics import classification_metrics, regression_metrics
+from .splits import spatial_folds, temporal_masks
+
+
+def _fit_predict_regression(name: str, feats: str, train: pd.DataFrame, test: pd.DataFrame) -> dict:
+    est = make_regressors()[name]
+    est.fit(feature_matrix(train, feats), train[REGRESSION_TARGET].to_numpy(dtype=float))
+    pred = est.predict(feature_matrix(test, feats))
+    return regression_metrics(test[REGRESSION_TARGET].to_numpy(dtype=float), pred)
+
+
+def _fit_predict_classification(name: str, feats: str, train: pd.DataFrame, test: pd.DataFrame) -> dict:
+    est = make_classifiers()[name]
+    y_train = train[CLASSIFICATION_TARGET].to_numpy(dtype=int)
+    est.fit(feature_matrix(train, feats), y_train)
+    if hasattr(est, "predict_proba"):
+        score = est.predict_proba(feature_matrix(test, feats))[:, 1]
+    else:  # pragma: no cover - all configured classifiers expose predict_proba
+        score = est.predict(feature_matrix(test, feats)).astype(float)
+    return classification_metrics(test[CLASSIFICATION_TARGET].to_numpy(dtype=int), score)
+
+
+def _temporal_leaderboard(train: pd.DataFrame, test: pd.DataFrame) -> dict:
+    regression: dict[str, dict] = {
+        "Mean": regression_metrics(
+            test[REGRESSION_TARGET].to_numpy(dtype=float),
+            MeanBaseline().fit(train, REGRESSION_TARGET).predict(test),
+        ),
+        "CountyHistory": regression_metrics(
+            test[REGRESSION_TARGET].to_numpy(dtype=float),
+            CountyHistoryBaseline().fit(train, REGRESSION_TARGET).predict(test),
+        ),
+    }
+    for name in make_regressors():
+        regression[f"{name}[severity]"] = _fit_predict_regression(name, "severity", train, test)
+        regression[f"{name}[climate]"] = _fit_predict_regression(name, "climate", train, test)
+
+    classification: dict[str, dict] = {
+        "PositiveRate": classification_metrics(
+            test[CLASSIFICATION_TARGET].to_numpy(dtype=int),
+            MeanBaseline().fit(train, CLASSIFICATION_TARGET).predict(test),
+        ),
+        "CountyHistory": classification_metrics(
+            test[CLASSIFICATION_TARGET].to_numpy(dtype=int),
+            CountyHistoryBaseline().fit(train, CLASSIFICATION_TARGET).predict(test),
+        ),
+    }
+    for name in make_classifiers():
+        classification[f"{name}[severity]"] = _fit_predict_classification(name, "severity", train, test)
+        classification[f"{name}[climate]"] = _fit_predict_classification(name, "climate", train, test)
+
+    return {"regression": regression, "classification": classification}
+
+
+def _spatial_summary(benchmark: pd.DataFrame) -> dict:
+    """Mean classification metrics across leave-one-state-out folds for the climate RF/GBM."""
+    summary: dict[str, dict] = {}
+    for name in ("RandomForest", "GradientBoost"):
+        aucs, aps = [], []
+        for _state, tr_mask, te_mask in spatial_folds(benchmark):
+            tr, te = benchmark[tr_mask], benchmark[te_mask]
+            if te[CLASSIFICATION_TARGET].nunique() < 2 or tr[CLASSIFICATION_TARGET].nunique() < 2:
+                continue
+            m = _fit_predict_classification(name, "climate", tr, te)
+            aucs.append(m["roc_auc"])
+            aps.append(m["pr_auc"])
+        summary[f"{name}[climate]"] = {
+            "mean_roc_auc": float(np.nanmean(aucs)) if aucs else float("nan"),
+            "mean_pr_auc": float(np.nanmean(aps)) if aps else float("nan"),
+            "n_folds": len(aucs),
+        }
+    return summary
+
+
+def run_leaderboard(benchmark: pd.DataFrame, cfg: DroughtConfig, *, write_dir: Path | None = None) -> dict:
+    """Compute the full leaderboard; optionally persist report + CSV to ``write_dir``."""
+    train_mask, test_mask = temporal_masks(benchmark, cfg)
+    train, test = benchmark[train_mask], benchmark[test_mask]
+    if len(train) == 0 or len(test) == 0:
+        raise ValueError("Temporal split produced an empty train or test set; check config years.")
+
+    report = {
+        "temporal": _temporal_leaderboard(train, test),
+        "spatial_loso": _spatial_summary(benchmark),
+        "counts": {"n_train": int(len(train)), "n_test": int(len(test)), "test_years": list(cfg.test_years)},
+    }
+
+    if write_dir is not None:
+        write_dir = Path(write_dir)
+        write_dir.mkdir(parents=True, exist_ok=True)
+        (write_dir / "evaluate_report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+        _leaderboard_frame(report).to_csv(write_dir / "leaderboard.csv", index=False)
+    return report
+
+
+def _leaderboard_frame(report: dict) -> pd.DataFrame:
+    rows = []
+    for task, models in report["temporal"].items():
+        for model, metrics in models.items():
+            rows.append({"split": "temporal", "task": task, "model": model, **metrics})
+    return pd.DataFrame(rows)

--- a/terraflow/drought/labels.py
+++ b/terraflow/drought/labels.py
@@ -1,0 +1,75 @@
+"""Build county-crop-year drought-loss labels from parsed RMA Cause of Loss records.
+
+The impact label is what makes this benchmark distinct from severity (USDM D2+) and yield
+(CY-Bench/SustainBench) benchmarks: it is the *insured drought loss* actually paid out.
+
+For each (GEOID, commodity_year) with commodity == ``crop`` and state in scope:
+- ``drought_indemnity``  = Σ indemnity where cause_of_loss_desc ∈ drought_causes
+- ``total_indemnity``    = Σ indemnity over all causes
+- ``liability``          = Σ liability over the county-crop-year's loss records
+- ``drought_share``      = drought_indemnity / total_indemnity            (clean, in [0, 1])
+- ``drought_loss_ratio`` = drought_indemnity / liability                  (primary regression target)
+- ``significant_drought_loss`` = drought_loss_ratio ≥ threshold           (binary target)
+
+Note on the denominator: ``liability`` is summed over the county-crop-year's Cause of Loss rows,
+which represent loss-experiencing policies (COL only contains indemnified experience). It is a
+well-defined loss-experience ratio, not the full insured liability — and can exceed 1.0 in
+catastrophic county-years (verified: up to ~1.11 in the 2012 Corn Belt). Rank-based metrics
+(Spearman) and the binary target are therefore the robust headlines; ``drought_share`` is provided
+as a fully double-count-free, bounded [0, 1] auxiliary target.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import DroughtConfig
+
+LABEL_COLUMNS: tuple[str, ...] = (
+    "GEOID",
+    "year",
+    "drought_indemnity",
+    "total_indemnity",
+    "liability",
+    "drought_share",
+    "drought_loss_ratio",
+    "significant_drought_loss",
+)
+
+
+def build_labels(col: pd.DataFrame, cfg: DroughtConfig) -> pd.DataFrame:
+    """Aggregate parsed Cause of Loss records into per-(GEOID, year) drought-loss labels."""
+    scoped = col[
+        col["state_code"].isin(cfg.states)
+        & (col["commodity_name"] == cfg.crop)
+        & col["commodity_year"].between(cfg.year_min, cfg.year_max)
+    ].copy()
+
+    scoped["_is_drought"] = scoped["cause_of_loss_desc"].isin(cfg.drought_causes)
+    scoped["_drought_indemnity"] = np.where(scoped["_is_drought"], scoped["indemnity_amount"], 0.0)
+
+    grouped = scoped.groupby(["GEOID", "commodity_year"], as_index=False).agg(
+        drought_indemnity=("_drought_indemnity", "sum"),
+        total_indemnity=("indemnity_amount", "sum"),
+        liability=("liability", "sum"),
+    )
+    grouped = grouped.rename(columns={"commodity_year": "year"})
+
+    grouped["drought_share"] = _safe_ratio(grouped["drought_indemnity"], grouped["total_indemnity"])
+    grouped["drought_loss_ratio"] = _safe_ratio(grouped["drought_indemnity"], grouped["liability"])
+    grouped["significant_drought_loss"] = grouped["drought_loss_ratio"] >= cfg.loss_ratio_threshold
+
+    grouped["year"] = grouped["year"].astype(int)
+    return grouped[list(LABEL_COLUMNS)].sort_values(["GEOID", "year"]).reset_index(drop=True)
+
+
+def _safe_ratio(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+    """numerator / denominator with 0 where the denominator is 0 (no loss experience)."""
+    out = np.divide(
+        numerator.to_numpy(dtype=float),
+        denominator.to_numpy(dtype=float),
+        out=np.zeros(len(numerator), dtype=float),
+        where=denominator.to_numpy(dtype=float) > 0,
+    )
+    return pd.Series(out, index=numerator.index)

--- a/terraflow/drought/metrics.py
+++ b/terraflow/drought/metrics.py
@@ -1,0 +1,54 @@
+"""Evaluation metrics for the drought-impact benchmark.
+
+Regression (continuous ``drought_loss_ratio``): R², RMSE, and Spearman rank correlation — the
+rank metric is the robust headline because the loss-experience ratio has a heavy tail and can
+exceed 1 (see :mod:`terraflow.drought.labels`).
+
+Classification (binary ``significant_drought_loss``): ROC-AUC, average precision (PR-AUC — the
+positive class is imbalanced, so PR-AUC is the honest headline), and Brier score.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+from scipy.stats import spearmanr
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    mean_squared_error,
+    r2_score,
+    roc_auc_score,
+)
+
+
+def regression_metrics(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, float]:
+    """R², RMSE, Spearman ρ. Returns NaNs gracefully for degenerate inputs."""
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    rmse = float(np.sqrt(mean_squared_error(y_true, y_pred)))
+    r2 = float(r2_score(y_true, y_pred)) if len(np.unique(y_true)) > 1 else float("nan")
+    # Spearman is undefined if either input is constant (e.g. a constant-mean baseline).
+    constant = np.unique(y_true).size < 2 or np.unique(y_pred).size < 2
+    if len(y_true) <= 2 or constant:
+        rho = float("nan")
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            rho = float(spearmanr(y_true, y_pred).statistic)
+    return {"r2": r2, "rmse": rmse, "spearman": rho}
+
+
+def classification_metrics(y_true: np.ndarray, y_score: np.ndarray) -> dict[str, float]:
+    """ROC-AUC, average precision (PR-AUC), Brier. AUC/AP are NaN if only one class present."""
+    y_true = np.asarray(y_true, dtype=int)
+    y_score = np.asarray(y_score, dtype=float)
+    single_class = len(np.unique(y_true)) < 2
+    return {
+        "roc_auc": float("nan") if single_class else float(roc_auc_score(y_true, y_score)),
+        "pr_auc": float("nan") if single_class else float(average_precision_score(y_true, y_score)),
+        "brier": float(brier_score_loss(y_true, np.clip(y_score, 0.0, 1.0))),
+        "positives": int(y_true.sum()),
+        "n": int(len(y_true)),
+    }

--- a/terraflow/drought/predictors.py
+++ b/terraflow/drought/predictors.py
@@ -1,0 +1,68 @@
+"""Aggregate flashdry within-season predictors to one vector per (GEOID, crop-year).
+
+The flashdry ``feature_table.parquet`` is sub-annual (growing-season, ~biweekly). For an
+early-warning task we aggregate each base feature over the season *up to* ``cutoff_doy`` — so a
+model only sees signal available by, e.g., end of July — into {mean, min, max, last} summaries.
+
+Two feature families are tagged so baselines can select them:
+- **climate/vegetation** — the 30 deseasonalized ``*_anom`` features + ``NDVI_anom_z``
+- **severity** — ``dm_gte_d2`` / ``dm_class`` (USDM drought severity). Aggregating these lets us
+  build a *severity-only* baseline and quantify how much within-season climate signal adds on top
+  of the (strong) USDM severity indicator for predicting realized drought *loss*.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .config import DroughtConfig
+
+# 30 deseasonalized anomaly features (primary climate inputs).
+_VARS = ("precip_m", "VPD_kPa", "swvl1", "Tmax_K", "Tmean_C", "dm_prcp")
+_WINDOWS = (7, 14, 30, 60, 90)
+ANOM_FEATURES: tuple[str, ...] = tuple(f"{v}_{w}d_anom" for v in _VARS for w in _WINDOWS)
+CLIMATE_FEATURES: tuple[str, ...] = ANOM_FEATURES + ("NDVI_anom_z",)
+SEVERITY_FEATURES: tuple[str, ...] = ("dm_gte_d2", "dm_class")
+
+_STATS = ("mean", "min", "max", "last")
+
+
+def _feature_columns(bases: tuple[str, ...]) -> list[str]:
+    """Output column names produced for a set of base features."""
+    return [f"{b}_{s}" for b in bases for s in _STATS]
+
+
+def climate_predictor_columns() -> list[str]:
+    return _feature_columns(CLIMATE_FEATURES)
+
+
+def severity_predictor_columns() -> list[str]:
+    return _feature_columns(SEVERITY_FEATURES)
+
+
+def aggregate_predictors(feature_table: pd.DataFrame, cfg: DroughtConfig) -> pd.DataFrame:
+    """Aggregate within-season predictors up to ``cfg.cutoff_doy`` per (GEOID, year).
+
+    Returns one row per (GEOID, year) with {mean, min, max, last} of every climate and severity
+    feature, plus ``n_obs`` (observations before the cutoff) and ``n_stress_weeks`` (vegetation
+    ≤ −1 SD). ``last`` is the value at the largest DOY at or before the cutoff.
+    """
+    df = feature_table[
+        (feature_table["doy"] <= cfg.cutoff_doy)
+        & feature_table["year"].between(cfg.year_min, cfg.year_max)
+        & feature_table["STATEFP"].isin(cfg.states)
+    ].copy()
+    df = df.sort_values(["GEOID", "year", "doy"])
+
+    bases = list(CLIMATE_FEATURES + SEVERITY_FEATURES)
+    agg_spec = {b: list(_STATS) for b in bases}
+    grouped = df.groupby(["GEOID", "year"]).agg(agg_spec)
+    grouped.columns = [f"{base}_{stat}" for base, stat in grouped.columns]
+
+    extras = df.groupby(["GEOID", "year"]).agg(
+        n_obs=("doy", "size"),
+        n_stress_weeks=("NDVI_anom_z", lambda s: int((s <= -1.0).sum())),
+    )
+    out = grouped.join(extras).reset_index()
+    out["year"] = out["year"].astype(int)
+    return out

--- a/terraflow/drought/rma.py
+++ b/terraflow/drought/rma.py
@@ -1,0 +1,179 @@
+"""Ingest USDA RMA *Cause of Loss* Summary-of-Business files.
+
+The Cause of Loss Historical Data Files are public, pipe-delimited flat files (one ZIP per year,
+1989–present) published at
+https://www.rma.usda.gov/tools-reports/summary-of-business/cause-loss
+
+Each record is broken down by year × state × county × commodity × insurance-plan × coverage ×
+stage × cause-of-loss × month-of-loss. The 30-field record layout is stable across the benchmark's
+year range (verified 2000 & 2012 → exactly 30 fields). Fields are space-padded within the pipe
+delimiters and numerics are zero-/dot-padded (e.g. ``00.0000000000``), so string fields are
+stripped and numeric fields coerced.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+BASE_URL = "https://pubfs-rma.fpac.usda.gov/pub/Web_Data_Files/Summary_of_Business/cause_of_loss"
+
+# The 30 fields in record-layout order (COL_Summary_of_Business_with_Month_All_Years).
+COL_COLUMNS: tuple[str, ...] = (
+    "commodity_year",
+    "state_code",
+    "state_abbrev",
+    "county_code",
+    "county_name",
+    "commodity_code",
+    "commodity_name",
+    "insurance_plan_code",
+    "insurance_plan_abbrev",
+    "coverage_category",
+    "stage_code",
+    "cause_of_loss_code",
+    "cause_of_loss_desc",
+    "month_of_loss",
+    "month_of_loss_name",
+    "year_of_loss",
+    "policies_earning_premium",
+    "policies_indemnified",
+    "net_planted_qty",
+    "net_endorsed_acres",
+    "liability",
+    "total_premium",
+    "producer_paid_premium",
+    "subsidy",
+    "state_private_subsidy",
+    "additional_subsidy",
+    "efa_premium_discount",
+    "net_determined_qty",
+    "indemnity_amount",
+    "loss_ratio",
+)
+
+# Columns coerced to numeric; everything else is a stripped string.
+_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "commodity_year",
+    "net_planted_qty",
+    "net_endorsed_acres",
+    "liability",
+    "total_premium",
+    "producer_paid_premium",
+    "subsidy",
+    "state_private_subsidy",
+    "additional_subsidy",
+    "efa_premium_discount",
+    "net_determined_qty",
+    "indemnity_amount",
+    "loss_ratio",
+)
+
+
+def col_url(year: int) -> str:
+    """Public download URL for a given commodity year's Cause of Loss ZIP."""
+    return f"{BASE_URL}/colsom_{year}.zip"
+
+
+def download_col_years(years: list[int], dest_dir: Path, *, overwrite: bool = False) -> list[Path]:
+    """Download (and cache) the Cause of Loss ZIP for each year into *dest_dir*.
+
+    Returns the list of local ZIP paths. Existing files are reused unless ``overwrite=True``.
+    """
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for year in years:
+        target = dest_dir / f"colsom_{year}.zip"
+        if overwrite or not target.exists():
+            urllib.request.urlretrieve(col_url(year), target)  # noqa: S310 (trusted USDA host)
+        paths.append(target)
+    return paths
+
+
+def _open_col_text(path: Path):
+    """Yield a readable text handle for a colsom file, transparently unzipping ``.zip``."""
+    path = Path(path)
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            name = next(n for n in zf.namelist() if n.lower().endswith(".txt"))
+            return zf.open(name)
+    return path.open("rb")
+
+
+def parse_col_file(
+    path: Path,
+    *,
+    states: list[str] | None = None,
+    commodity: str | None = None,
+) -> pd.DataFrame:
+    """Parse a single Cause of Loss file (``.txt`` or ``.zip``) into a tidy DataFrame.
+
+    String fields are stripped; numeric fields are coerced. Adds a 5-digit ``GEOID`` (state FIPS +
+    county FIPS) matching the flashdry predictor tables. Optional ``states`` / ``commodity`` filters
+    are applied *before* the (costly) strip/convert of every column, which keeps whole-corpus loads
+    fast when only one crop/region is needed.
+    """
+    handle = _open_col_text(path)
+    try:
+        df = pd.read_csv(
+            handle,
+            sep="|",
+            header=None,
+            names=list(COL_COLUMNS),
+            dtype=str,
+            encoding="latin-1",
+            na_filter=False,
+        )
+    finally:
+        handle.close()
+
+    # Cheap early filter on just the two key columns to shrink the frame before full processing.
+    if states is not None:
+        df = df[df["state_code"].str.strip().str.zfill(2).isin(states)]
+    if commodity is not None:
+        df = df[df["commodity_name"].str.strip() == commodity]
+    df = df.copy()
+
+    for col in COL_COLUMNS:
+        df[col] = df[col].str.strip()
+    for col in _NUMERIC_COLUMNS:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    df["state_code"] = df["state_code"].str.zfill(2)
+    df["county_code"] = df["county_code"].str.zfill(3)
+    df["GEOID"] = df["state_code"] + df["county_code"]
+    return df
+
+
+def load_col(
+    rma_dir: Path,
+    years: list[int],
+    *,
+    states: list[str] | None = None,
+    commodity: str | None = None,
+) -> pd.DataFrame:
+    """Load and concatenate Cause of Loss records for *years* from *rma_dir*.
+
+    Accepts either ``colsom_YYYY.zip`` or the extracted ``colsomYY.txt`` in *rma_dir*. ``states`` /
+    ``commodity`` filters are pushed down into each file for speed.
+    """
+    rma_dir = Path(rma_dir)
+    frames: list[pd.DataFrame] = []
+    for year in years:
+        candidates = [
+            rma_dir / f"colsom_{year}.zip",
+            rma_dir / f"colsom{year % 100:02d}.txt",
+            rma_dir / f"colsom_{year}.txt",
+        ]
+        path = next((c for c in candidates if c.exists()), None)
+        if path is None:
+            raise FileNotFoundError(
+                f"No Cause of Loss file for {year} in {rma_dir} "
+                f"(expected one of: {', '.join(c.name for c in candidates)})"
+            )
+        frames.append(parse_col_file(path, states=states, commodity=commodity))
+    return pd.concat(frames, ignore_index=True)

--- a/terraflow/drought/splits.py
+++ b/terraflow/drought/splits.py
@@ -1,0 +1,61 @@
+"""Reproducible evaluation splits for the drought-impact benchmark.
+
+Three complementary regimes, all deterministic from the config (no RNG):
+- **temporal** — held-out years (incl. the 2012 extreme + recent 2022/2023) test extrapolation to
+  unseen seasons.
+- **spatial** — leave-one-state-out blocks test spatial transfer (guards against spatially
+  autocorrelated leakage; finer lon/lat grids are a follow-up).
+- **loyo** — leave-one-year-out folds for a stability estimate across all years.
+
+Split *definitions* (not enumerated rows) are serialized so the artifact is small and the masks
+are re-derivable from any benchmark table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import numpy as np
+import pandas as pd
+
+from .config import DroughtConfig
+
+
+def temporal_masks(df: pd.DataFrame, cfg: DroughtConfig) -> tuple[np.ndarray, np.ndarray]:
+    """(train_mask, test_mask) for the official temporal split."""
+    test = df["year"].isin(cfg.test_years).to_numpy()
+    train = (~test) & (df["year"] <= cfg.train_max_year).to_numpy()
+    return train, test
+
+
+def spatial_block_ids(df: pd.DataFrame) -> pd.Series:
+    """State-level spatial block id (first two GEOID digits = state FIPS)."""
+    return df["GEOID"].str[:2]
+
+
+def spatial_folds(df: pd.DataFrame) -> Iterator[tuple[str, np.ndarray, np.ndarray]]:
+    """Leave-one-state-out folds: (state, train_mask, test_mask)."""
+    blocks = spatial_block_ids(df)
+    for state in sorted(blocks.unique()):
+        test = (blocks == state).to_numpy()
+        yield state, ~test, test
+
+
+def loyo_folds(df: pd.DataFrame) -> Iterator[tuple[int, np.ndarray, np.ndarray]]:
+    """Leave-one-year-out folds: (year, train_mask, test_mask)."""
+    for year in sorted(df["year"].unique()):
+        test = (df["year"] == year).to_numpy()
+        yield int(year), ~test, test
+
+
+def describe_splits(cfg: DroughtConfig) -> dict:
+    """JSON-serializable split definition (re-derivable, not enumerated)."""
+    return {
+        "temporal": {
+            "test_years": list(cfg.test_years),
+            "train_max_year": cfg.train_max_year,
+            "rule": "test = year in test_years; train = remaining years <= train_max_year",
+        },
+        "spatial": {"scheme": "leave-one-state-out", "block_key": "GEOID[:2]"},
+        "loyo": {"scheme": "leave-one-year-out", "years": cfg.years},
+    }

--- a/tests/drought_synthetic.py
+++ b/tests/drought_synthetic.py
@@ -1,0 +1,109 @@
+"""Synthetic data builders for drought-benchmark tests (no network, tiny, deterministic)."""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from terraflow.drought.predictors import ANOM_FEATURES
+
+# 30-field Cause of Loss record order (see terraflow.drought.rma.COL_COLUMNS).
+_COL_TEMPLATE = (
+    "{year}|{state}|{abbr}|{county}|{cname}|0041|{commodity}|02|RP   |A|H |{cl_code}|{cause}|"
+    "07|JUL|{year}|1|1|100.00|.00|{liability}.00|500.00|250.00|250.00|.00|.00|.00|"
+    "50.00|{indemnity}.00|{ratio}"
+)
+
+
+def write_synthetic_col(path: Path, rows: list[dict]) -> Path:
+    """Write a pipe-delimited COL ``.txt`` (or ``.zip`` if path ends in .zip) from row dicts."""
+    lines = []
+    for r in rows:
+        liability = float(r.get("liability", 1000.0))
+        indemnity = float(r.get("indemnity", 0.0))
+        lines.append(
+            _COL_TEMPLATE.format(
+                year=r["year"],
+                state=str(r["state"]).zfill(2),
+                abbr=r.get("abbr", "IL"),
+                county=str(r["county"]).zfill(3),
+                cname=r.get("cname", "Test County").ljust(30),
+                commodity=r.get("commodity", "CORN").ljust(30),
+                cl_code=r.get("cl_code", "31"),
+                cause=r.get("cause", "Drought").ljust(35),
+                liability=int(liability),
+                indemnity=int(indemnity),
+                ratio=f"{(indemnity / max(liability, 1)):.2f}",
+            )
+        )
+    text = "\n".join(lines) + "\n"
+    path = Path(path)
+    if path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("colsom_synthetic.txt", text)
+    else:
+        path.write_text(text, encoding="latin-1")
+    return path
+
+
+def make_feature_table(
+    geoids: list[str],
+    years: list[int],
+    doys: tuple[int, ...] = (130, 160, 190, 220),
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Minimal feature table with the columns predictors need, filled deterministically."""
+    rng = np.random.default_rng(seed)
+    recs = []
+    for g in geoids:
+        for y in years:
+            # Give each county-year a latent "stress" that drives both anomalies and severity.
+            stress = rng.normal(0, 1)
+            for d in doys:
+                rec: dict[str, object] = {
+                    "GEOID": g,
+                    "STATEFP": g[:2],
+                    "NAME": "Test",
+                    "year": y,
+                    "doy": d,
+                    "NDVI_anom_z": -stress + rng.normal(0, 0.2),
+                    "dm_gte_d2": bool(stress > 0.5),
+                    "dm_class": int(np.clip(round(stress + 2), 0, 4)),
+                }
+                for f in ANOM_FEATURES:
+                    rec[f] = stress + rng.normal(0, 0.3)
+                recs.append(rec)
+    return pd.DataFrame(recs)
+
+
+def make_benchmark(
+    geoids: list[str],
+    years: list[int],
+    seed: int = 0,
+) -> pd.DataFrame:
+    """A tiny assembled-style benchmark table (predictor columns + labels) for evaluate tests."""
+    from terraflow.drought.baselines import feature_columns
+
+    rng = np.random.default_rng(seed)
+    cols = feature_columns("all")
+    recs = []
+    for g in geoids:
+        for y in years:
+            stress = rng.normal(0, 1)
+            ratio = max(0.0, 0.15 * stress + rng.normal(0, 0.02))
+            rec: dict[str, object] = {"GEOID": g, "year": y}
+            for c in cols:
+                rec[c] = stress + rng.normal(0, 0.3)
+            rec["n_obs"] = 4
+            rec["n_stress_weeks"] = int(stress > 0.5)
+            rec["drought_indemnity"] = max(0.0, stress) * 1000
+            rec["total_indemnity"] = abs(stress) * 1000 + 1
+            rec["liability"] = 10000.0
+            rec["drought_share"] = 0.5
+            rec["drought_loss_ratio"] = ratio
+            rec["significant_drought_loss"] = ratio >= 0.10
+            recs.append(rec)
+    return pd.DataFrame(recs)

--- a/tests/test_drought_cli.py
+++ b/tests/test_drought_cli.py
@@ -1,0 +1,95 @@
+"""Tests for the `terraflow drought` CLI sub-app and backward-compatibility of existing commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from terraflow.cli import app
+
+from .drought_synthetic import make_benchmark, make_feature_table, write_synthetic_col
+
+runner = CliRunner()
+
+
+def test_existing_commands_still_work():
+    # Adding the drought sub-app must not break the original commands.
+    for cmd in ("run", "sensitivity", "validate"):
+        result = runner.invoke(app, [cmd, "--help"])
+        assert result.exit_code == 0, result.output
+
+
+def test_drought_help_lists_subcommands():
+    result = runner.invoke(app, ["drought", "--help"])
+    assert result.exit_code == 0
+    for sub in ("fetch", "build", "evaluate"):
+        assert sub in result.output
+
+
+def _write_config(tmp_path: Path, **over) -> Path:
+    lines = {
+        "states": "['17', '19']",
+        "year_min": 2000,
+        "year_max": 2001,
+        "rma_dir": f'"{tmp_path}"',
+        "feature_table": f'"{tmp_path / "feature_table.parquet"}"',
+        "output_dir": f'"{tmp_path / "out"}"',
+    }
+    lines.update(over)
+    body = "\n".join(f"{k}: {v}" for k, v in lines.items())
+    path = tmp_path / "cfg.yml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_cli_build(tmp_path: Path):
+    geoids = ["17001", "19005"]
+    make_feature_table(geoids, [2000, 2001]).to_parquet(tmp_path / "feature_table.parquet", index=False)
+    for y in (2000, 2001):
+        rows = [
+            {
+                "year": y,
+                "state": g[:2],
+                "county": g[2:],
+                "commodity": "CORN",
+                "cause": "Drought",
+                "liability": 1000,
+                "indemnity": 300,
+            }
+            for g in geoids
+        ]
+        write_synthetic_col(tmp_path / f"colsom_{y}.zip", rows)
+
+    cfg = _write_config(tmp_path)
+    result = runner.invoke(app, ["drought", "build", "-c", str(cfg)])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "out" / "benchmark.parquet").exists()
+
+
+def test_cli_evaluate(tmp_path: Path):
+    # Pre-write a benchmark so evaluate can load it directly.
+    out = tmp_path / "out"
+    out.mkdir()
+    geoids = [f"{s}{c:03d}" for s in ("17", "19") for c in range(1, 6)]
+    make_benchmark(geoids, [2000, 2001, 2002, 2003]).to_parquet(out / "benchmark.parquet", index=False)
+
+    cfg = _write_config(tmp_path, year_max=2003, test_years="[2003]", train_max_year=2002, states="['17', '19']")
+    result = runner.invoke(app, ["drought", "evaluate", "-c", str(cfg)])
+    assert result.exit_code == 0, result.output
+    assert (out / "leaderboard.csv").exists()
+
+
+def test_cli_fetch_monkeypatched(tmp_path: Path, monkeypatch):
+    calls = {}
+
+    def fake_download(years, dest_dir, *, overwrite=False):
+        calls["years"] = years
+        return [Path(dest_dir) / f"colsom_{y}.zip" for y in years]
+
+    monkeypatch.setattr("terraflow.drought.cli.download_col_years", fake_download)
+    result = runner.invoke(
+        app, ["drought", "fetch", "--rma-dir", str(tmp_path), "--year-min", "2000", "--year-max", "2001"]
+    )
+    assert result.exit_code == 0, result.output
+    assert calls["years"] == [2000, 2001]

--- a/tests/test_drought_features.py
+++ b/tests/test_drought_features.py
@@ -1,0 +1,107 @@
+"""Tests for predictor aggregation, splits, and metrics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from terraflow.drought.config import DroughtConfig
+from terraflow.drought.metrics import classification_metrics, regression_metrics
+from terraflow.drought.predictors import (
+    aggregate_predictors,
+    climate_predictor_columns,
+    severity_predictor_columns,
+)
+from terraflow.drought.splits import (
+    describe_splits,
+    loyo_folds,
+    spatial_folds,
+    temporal_masks,
+)
+
+from .drought_synthetic import make_feature_table
+
+
+def _cfg(tmp_path: Path, **kw) -> DroughtConfig:
+    d = dict(
+        states=["17", "19"],
+        year_min=2000,
+        year_max=2001,
+        rma_dir=tmp_path,
+        feature_table=tmp_path / "x",
+        output_dir=tmp_path / "o",
+    )
+    d.update(kw)
+    return DroughtConfig(**d)
+
+
+def test_aggregate_respects_cutoff_and_shapes(tmp_path: Path):
+    ft = make_feature_table(["17001", "19005"], [2000, 2001], doys=(130, 160, 190, 220))
+    cfg = _cfg(tmp_path, cutoff_doy=200)
+    out = aggregate_predictors(ft, cfg)
+
+    assert set(zip(out["GEOID"], out["year"])) == {("17001", 2000), ("17001", 2001), ("19005", 2000), ("19005", 2001)}
+    # doy 220 is past the cutoff → 3 obs per county-year.
+    assert (out["n_obs"] == 3).all()
+    for col in climate_predictor_columns()[:2] + severity_predictor_columns()[:2]:
+        assert col in out.columns
+    assert "n_stress_weeks" in out.columns
+
+
+def test_aggregate_last_is_value_at_max_doy(tmp_path: Path):
+    ft = make_feature_table(["17001"], [2000], doys=(130, 160, 190))
+    cfg = _cfg(tmp_path, cutoff_doy=300)
+    out = aggregate_predictors(ft, cfg)
+    expected_last = ft[(ft.doy == 190)]["NDVI_anom_z"].iloc[0]
+    assert out["NDVI_anom_z_last"].iloc[0] == expected_last
+
+
+def test_temporal_masks_disjoint(tmp_path: Path):
+    import pandas as pd
+
+    df = pd.DataFrame({"GEOID": ["17001"] * 5, "year": [2000, 2001, 2002, 2012, 2017]})
+    cfg = _cfg(tmp_path, year_max=2017, test_years=[2012, 2017], train_max_year=2002)
+    train, test = temporal_masks(df, cfg)
+    assert not (train & test).any()
+    assert list(df["year"][test]) == [2012, 2017]
+    assert set(df["year"][train]) == {2000, 2001, 2002}
+
+
+def test_spatial_and_loyo_folds(tmp_path: Path):
+    import pandas as pd
+
+    df = pd.DataFrame({"GEOID": ["17001", "17003", "19001", "19003"], "year": [2000, 2001, 2000, 2001]})
+    states = [s for s, _tr, _te in spatial_folds(df)]
+    assert states == ["17", "19"]
+    for _s, tr, te in spatial_folds(df):
+        assert not (tr & te).any()
+    years = [y for y, _tr, _te in loyo_folds(df)]
+    assert years == [2000, 2001]
+
+
+def test_describe_splits_keys(tmp_path: Path):
+    d = describe_splits(_cfg(tmp_path))
+    assert set(d) == {"temporal", "spatial", "loyo"}
+    assert d["spatial"]["scheme"] == "leave-one-state-out"
+
+
+def test_regression_metrics():
+    y = np.array([0.0, 1.0, 2.0, 3.0])
+    perfect = regression_metrics(y, y)
+    assert perfect["spearman"] == 1.0
+    assert perfect["rmse"] == 0.0
+    # constant prediction → spearman undefined (NaN), no warning/crash.
+    const = regression_metrics(y, np.ones_like(y))
+    assert np.isnan(const["spearman"])
+
+
+def test_classification_metrics():
+    y = np.array([0, 0, 1, 1])
+    sep = classification_metrics(y, np.array([0.1, 0.2, 0.8, 0.9]))
+    assert sep["roc_auc"] == 1.0
+    assert sep["positives"] == 2
+    # single-class truth → AUC/AP undefined but Brier still defined.
+    single = classification_metrics(np.array([0, 0, 0]), np.array([0.1, 0.2, 0.3]))
+    assert np.isnan(single["roc_auc"])
+    assert not np.isnan(single["brier"])

--- a/tests/test_drought_features.py
+++ b/tests/test_drought_features.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from terraflow.drought.config import DroughtConfig
 from terraflow.drought.metrics import classification_metrics, regression_metrics
@@ -24,7 +25,7 @@ from .drought_synthetic import make_feature_table
 
 
 def _cfg(tmp_path: Path, **kw) -> DroughtConfig:
-    d = dict(
+    d: dict = dict(
         states=["17", "19"],
         year_min=2000,
         year_max=2001,
@@ -89,8 +90,8 @@ def test_describe_splits_keys(tmp_path: Path):
 def test_regression_metrics():
     y = np.array([0.0, 1.0, 2.0, 3.0])
     perfect = regression_metrics(y, y)
-    assert perfect["spearman"] == 1.0
-    assert perfect["rmse"] == 0.0
+    assert perfect["spearman"] == pytest.approx(1.0)
+    assert perfect["rmse"] == pytest.approx(0.0)
     # constant prediction → spearman undefined (NaN), no warning/crash.
     const = regression_metrics(y, np.ones_like(y))
     assert np.isnan(const["spearman"])
@@ -99,7 +100,7 @@ def test_regression_metrics():
 def test_classification_metrics():
     y = np.array([0, 0, 1, 1])
     sep = classification_metrics(y, np.array([0.1, 0.2, 0.8, 0.9]))
-    assert sep["roc_auc"] == 1.0
+    assert sep["roc_auc"] == pytest.approx(1.0)
     assert sep["positives"] == 2
     # single-class truth → AUC/AP undefined but Brier still defined.
     single = classification_metrics(np.array([0, 0, 0]), np.array([0.1, 0.2, 0.3]))

--- a/tests/test_drought_ingest.py
+++ b/tests/test_drought_ingest.py
@@ -14,7 +14,7 @@ from .drought_synthetic import write_synthetic_col
 
 
 def _cfg(tmp_path: Path, **kw) -> DroughtConfig:
-    defaults = dict(
+    defaults: dict = dict(
         states=["17", "19"],
         year_min=2000,
         year_max=2001,
@@ -51,7 +51,7 @@ def test_parse_txt_and_zip_agree(tmp_path: Path):
     assert list(df_txt.columns)[: len(COL_COLUMNS)] == list(COL_COLUMNS)
     assert df_txt.loc[0, "GEOID"] == "17001"
     assert df_txt.loc[0, "commodity_name"] == "CORN"  # stripped
-    assert df_txt.loc[0, "indemnity_amount"] == 300.0  # numeric-coerced
+    assert df_txt.loc[0, "indemnity_amount"] == pytest.approx(300.0)  # numeric-coerced
     assert df_zip.loc[0, "GEOID"] == "17001"
 
 
@@ -109,9 +109,9 @@ def test_build_labels_math(tmp_path: Path):
 
     assert list(labels.columns) == list(LABEL_COLUMNS)
     r = labels.iloc[0]
-    assert r["drought_indemnity"] == 300.0
-    assert r["total_indemnity"] == 400.0
-    assert r["liability"] == 3000.0
+    assert r["drought_indemnity"] == pytest.approx(300.0)
+    assert r["total_indemnity"] == pytest.approx(400.0)
+    assert r["liability"] == pytest.approx(3000.0)
     assert r["drought_share"] == pytest.approx(0.75)
     assert r["drought_loss_ratio"] == pytest.approx(0.1)  # 300/3000
     assert bool(r["significant_drought_loss"]) is True  # >= 0.10 threshold

--- a/tests/test_drought_ingest.py
+++ b/tests/test_drought_ingest.py
@@ -1,0 +1,128 @@
+"""Tests for RMA Cause of Loss ingest + label construction (terraflow.drought.rma/labels)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from terraflow.drought.config import DroughtConfig
+from terraflow.drought.labels import LABEL_COLUMNS, build_labels
+from terraflow.drought.rma import COL_COLUMNS, col_url, load_col, parse_col_file
+
+from .drought_synthetic import write_synthetic_col
+
+
+def _cfg(tmp_path: Path, **kw) -> DroughtConfig:
+    defaults = dict(
+        states=["17", "19"],
+        year_min=2000,
+        year_max=2001,
+        rma_dir=tmp_path,
+        feature_table=tmp_path / "ft.parquet",
+        output_dir=tmp_path / "out",
+    )
+    defaults.update(kw)
+    return DroughtConfig(**defaults)
+
+
+def test_col_url_pattern():
+    assert col_url(2012).endswith("/colsom_2012.zip")
+
+
+def test_parse_txt_and_zip_agree(tmp_path: Path):
+    rows = [
+        {
+            "year": 2000,
+            "state": 17,
+            "county": 1,
+            "commodity": "CORN",
+            "cause": "Drought",
+            "liability": 1000,
+            "indemnity": 300,
+        }
+    ]
+    txt = write_synthetic_col(tmp_path / "colsom00.txt", rows)
+    zip_ = write_synthetic_col(tmp_path / "colsom_2000.zip", rows)
+
+    df_txt = parse_col_file(txt)
+    df_zip = parse_col_file(zip_)
+
+    assert list(df_txt.columns)[: len(COL_COLUMNS)] == list(COL_COLUMNS)
+    assert df_txt.loc[0, "GEOID"] == "17001"
+    assert df_txt.loc[0, "commodity_name"] == "CORN"  # stripped
+    assert df_txt.loc[0, "indemnity_amount"] == 300.0  # numeric-coerced
+    assert df_zip.loc[0, "GEOID"] == "17001"
+
+
+def test_parse_pushdown_filters(tmp_path: Path):
+    rows = [
+        {"year": 2000, "state": 17, "county": 1, "commodity": "CORN", "cause": "Drought"},
+        {"year": 2000, "state": 55, "county": 1, "commodity": "CORN", "cause": "Drought"},
+        {"year": 2000, "state": 17, "county": 2, "commodity": "WHEAT", "cause": "Drought"},
+    ]
+    path = write_synthetic_col(tmp_path / "colsom00.txt", rows)
+    df = parse_col_file(path, states=["17"], commodity="CORN")
+    assert len(df) == 1
+    assert df.loc[0, "GEOID"] == "17001"
+
+
+def test_load_col_missing_year_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="No Cause of Loss file for 2000"):
+        load_col(tmp_path, [2000])
+
+
+def test_build_labels_math(tmp_path: Path):
+    # One county-year: two drought rows (indemnity 200+100) + one hail row (indemnity 100).
+    rows = [
+        {
+            "year": 2000,
+            "state": 17,
+            "county": 1,
+            "commodity": "CORN",
+            "cause": "Drought",
+            "liability": 1000,
+            "indemnity": 200,
+        },
+        {
+            "year": 2000,
+            "state": 17,
+            "county": 1,
+            "commodity": "CORN",
+            "cause": "Drought",
+            "liability": 1000,
+            "indemnity": 100,
+        },
+        {
+            "year": 2000,
+            "state": 17,
+            "county": 1,
+            "commodity": "CORN",
+            "cause": "Hail",
+            "liability": 1000,
+            "indemnity": 100,
+        },
+    ]
+    write_synthetic_col(tmp_path / "colsom00.txt", rows)
+    col = load_col(tmp_path, [2000], states=["17"], commodity="CORN")
+    labels = build_labels(col, _cfg(tmp_path))
+
+    assert list(labels.columns) == list(LABEL_COLUMNS)
+    r = labels.iloc[0]
+    assert r["drought_indemnity"] == 300.0
+    assert r["total_indemnity"] == 400.0
+    assert r["liability"] == 3000.0
+    assert r["drought_share"] == pytest.approx(0.75)
+    assert r["drought_loss_ratio"] == pytest.approx(0.1)  # 300/3000
+    assert bool(r["significant_drought_loss"]) is True  # >= 0.10 threshold
+
+
+def test_build_labels_filters_scope(tmp_path: Path):
+    rows = [
+        {"year": 2000, "state": 17, "county": 1, "commodity": "CORN", "cause": "Drought", "indemnity": 500},
+        {"year": 2000, "state": 17, "county": 2, "commodity": "SOYBEANS", "cause": "Drought", "indemnity": 500},
+    ]
+    write_synthetic_col(tmp_path / "colsom00.txt", rows)
+    col = load_col(tmp_path, [2000])
+    labels = build_labels(col, _cfg(tmp_path))  # crop defaults to CORN
+    assert set(labels["GEOID"]) == {"17001"}

--- a/tests/test_drought_pipeline.py
+++ b/tests/test_drought_pipeline.py
@@ -1,0 +1,115 @@
+"""Tests for benchmark assembly, determinism, and the leaderboard (dataset/evaluate)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from terraflow.drought.config import DroughtConfig
+from terraflow.drought.dataset import assemble_benchmark, load_benchmark
+from terraflow.drought.evaluate import run_leaderboard
+
+from .drought_synthetic import make_benchmark, make_feature_table, write_synthetic_col
+
+_STATES = ["17", "19"]
+_GEOIDS = ["17001", "19005"]
+
+
+def _setup_inputs(tmp_path: Path, years: list[int]) -> DroughtConfig:
+    ft = make_feature_table(_GEOIDS, years)
+    ft_path = tmp_path / "feature_table.parquet"
+    ft.to_parquet(ft_path, index=False)
+    for y in years:
+        rows = [
+            {
+                "year": y,
+                "state": g[:2],
+                "county": g[2:],
+                "commodity": "CORN",
+                "cause": "Drought",
+                "liability": 1000,
+                "indemnity": 300 if g == "17001" else 50,
+            }
+            for g in _GEOIDS
+        ]
+        write_synthetic_col(tmp_path / f"colsom_{y}.zip", rows)
+    return DroughtConfig(
+        states=_STATES,
+        year_min=min(years),
+        year_max=max(years),
+        rma_dir=tmp_path,
+        feature_table=ft_path,
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_assemble_writes_artifacts(tmp_path: Path):
+    cfg = _setup_inputs(tmp_path, [2000, 2001])
+    bench = assemble_benchmark(cfg, write=True)
+
+    assert len(bench) == 4  # 2 counties × 2 years
+    assert (cfg.output_dir / "benchmark.parquet").exists()
+    manifest = json.loads((cfg.output_dir / "manifest.json").read_text())
+    assert manifest["schema_version"] == "1"
+    assert len(manifest["build_fingerprint"]) == 64
+    assert manifest["n_counties"] == 2
+    assert (cfg.output_dir / "splits.json").exists()
+    # 17001 has ratio 0.3 (positive), 19005 has 0.05 (negative).
+    pos = bench.set_index("GEOID")["significant_drought_loss"]
+    assert bool(pos.loc["17001"].all()) is True
+    assert bool(pos.loc["19005"].any()) is False
+
+
+def test_assemble_is_deterministic(tmp_path: Path):
+    cfg = _setup_inputs(tmp_path, [2000, 2001])
+    assemble_benchmark(cfg, write=True)
+    fp1 = json.loads((cfg.output_dir / "manifest.json").read_text())["build_fingerprint"]
+    assemble_benchmark(cfg, write=True)
+    fp2 = json.loads((cfg.output_dir / "manifest.json").read_text())["build_fingerprint"]
+    assert fp1 == fp2
+
+
+def test_load_benchmark_missing(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="No benchmark"):
+        load_benchmark(tmp_path)
+
+
+def test_run_leaderboard_structure_and_files(tmp_path: Path):
+    geoids = [f"{s}{c:03d}" for s in ("17", "18", "19") for c in range(1, 6)]
+    bench = make_benchmark(geoids, [2000, 2001, 2002, 2003])
+    cfg = DroughtConfig(
+        states=["17", "18", "19"],
+        year_min=2000,
+        year_max=2003,
+        test_years=[2003],
+        train_max_year=2002,
+        rma_dir=tmp_path,
+        feature_table=tmp_path / "x",
+        output_dir=tmp_path / "out",
+    )
+    report = run_leaderboard(bench, cfg, write_dir=cfg.output_dir)
+
+    assert "regression" in report["temporal"] and "classification" in report["temporal"]
+    assert "Ridge[climate]" in report["temporal"]["regression"]
+    assert "LogReg[severity]" in report["temporal"]["classification"]
+    assert "spatial_loso" in report
+    assert (cfg.output_dir / "evaluate_report.json").exists()
+    assert (cfg.output_dir / "leaderboard.csv").exists()
+
+
+def test_run_leaderboard_empty_split_raises(tmp_path: Path):
+    bench = make_benchmark(["17001", "17003"], [2000, 2001])
+    cfg = DroughtConfig(
+        states=["17"],
+        year_min=2000,
+        year_max=2001,
+        test_years=[2099],
+        train_max_year=2001,
+        rma_dir=tmp_path,
+        feature_table=tmp_path / "x",
+        output_dir=tmp_path / "out",
+    )
+    with pytest.raises(ValueError, match="empty train or test"):
+        run_leaderboard(bench, cfg)

--- a/tests/test_drought_pipeline.py
+++ b/tests/test_drought_pipeline.py
@@ -97,6 +97,22 @@ def test_run_leaderboard_structure_and_files(tmp_path: Path):
     assert "spatial_loso" in report
     assert (cfg.output_dir / "evaluate_report.json").exists()
     assert (cfg.output_dir / "leaderboard.csv").exists()
+    # Report must be strict JSON: non-finite metrics (e.g. Mean-baseline Spearman) become null, not NaN.
+    report_text = (cfg.output_dir / "evaluate_report.json").read_text()
+    assert "NaN" not in report_text and "Infinity" not in report_text
+
+
+def test_classification_handles_one_class_training(tmp_path: Path):
+    # A training set with a single class must not crash the temporal classifiers.
+    from terraflow.drought.baselines import CLASSIFICATION_TARGET
+    from terraflow.drought.evaluate import _fit_predict_classification
+
+    bench = make_benchmark(["17001", "17003", "19001"], [2000, 2001, 2002])
+    train = bench[bench["year"] < 2002].copy()
+    train[CLASSIFICATION_TARGET] = False  # force one-class training
+    test = bench[bench["year"] == 2002]
+    metrics = _fit_predict_classification("LogReg", "climate", train, test)
+    assert "roc_auc" in metrics and "brier" in metrics
 
 
 def test_run_leaderboard_empty_split_raises(tmp_path: Path):


### PR DESCRIPTION
## What

Adds an in-package `terraflow.drought` sub-package + `terraflow drought {fetch,build,evaluate}` CLI that assembles and evaluates a **prediction-ready, impact-labeled drought benchmark**: predict **insured drought loss** (USDA RMA *Cause of Loss*, public 1989–present) from within-season climate/vegetation anomalies.

This is a decision-relevant **impact** target — distinct from drought *severity* (USDM D2+, what flashdry predicts) and crop *yield* benchmarks (CY-Bench / SustainBench). No prior shared ML benchmark uses RMA cause-of-loss as the label.

Supersedes and replaces the cloud-draft #162 (which used a self-contained layout + severity label); this is re-scoped to the RMA impact label and the in-package layout.

## Task (v0)

- **Unit:** (county `GEOID`, crop-year) — corn, 6-state Corn Belt (IL/IN/IA/MN/MO/NE), 2000–2023.
- **Targets:** `drought_loss_ratio` (regression) + `significant_drought_loss` (binary); bounded `drought_share` auxiliary.
- **Predictors:** 30 deseasonalized flashdry `*_anom` features + `NDVI_anom_z` + USDM severity, aggregated {mean,min,max,last} up to a configurable `cutoff_doy` (early-warning framing).
- **Splits:** temporal (held-out years incl. the 2012 extreme), leave-one-state-out spatial, LOYO.

## Reference results (real run: 587 counties, 13,895 county-years, 18.5% positive)

Temporal split (train ≤ 2015, test = 2012/2017/2022/2023):

| Task | Model | Headline |
|---|---|---|
| Classification | LogReg [climate] | ROC-AUC **0.93**, PR-AUC **0.78** |
| Classification | LogReg [severity] | ROC-AUC 0.92, PR-AUC 0.73 |
| Classification | RandomForest [climate] | ROC-AUC 0.27 (temporal-extrapolation collapse) |
| Regression | Ridge [climate] | Spearman **0.65** |
| Spatial LOSO | RandomForest [climate] | mean ROC-AUC **0.91** |

**Findings:** (1) within-season signal predicts insured drought loss well (AUC ≈ 0.91–0.93); (2) USDM severity is a *strong* baseline — climate anomalies match/slightly beat it and arrive earlier in the season; (3) **temporal extrapolation to extreme years is the open challenge** — tree models collapse under distribution shift while linear models hold.


## Reproducibility

`terraflow drought fetch` → `build -c examples/drought_v0_corn_6state.yml` → `evaluate ...`. `build` writes `benchmark.parquet` + `manifest.json` (deterministic SHA-256 build fingerprint via `terraflow.core.run_identity`) + `splits.json`.

## Notes / follow-ups

- No new runtime dependency (reuses scikit-learn / pandas / pyarrow). flashdry is consumed as data + citation only (no code dep, no nested git).
- **Known limitation:** RMA covers insured acres only; the loss-experience liability denominator can push `drought_loss_ratio` > 1 in catastrophic years → rank metrics + the binary target are the robust headlines (documented in the datasheet).
- Follow-ups: soybean, CONUS, a coverage-bias column, deep models, Zenodo dataset publication (two-tier).

## Checks

- 23 new tests (`tests/test_drought_*.py`); backward-compat guard for existing CLI.
- Full suite: **323 passed, 1 skipped, coverage 89%** (≥ 85% gate). ruff + mypy clean.
- Docs: guide, API autodoc, notebook (+ nav), sample config, data provenance, Makefile targets, CHANGELOG, README, CITATION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
