### PR TITLE
feat(drought): soybean benchmark (crop-parameterized)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+- **Drought benchmark: soybean support.** The `terraflow.drought` pipeline is crop-parameterized;
+  a soybean benchmark is available via `examples/drought_soybean_6state.yml` (RMA/SOB/NASS all key
+  on `SOYBEANS`). NDVI remains corn-masked (regional proxy for non-corn crops; documented).
 - **Drought benchmark coverage hardening.** `terraflow.drought` now derives the drought-loss-ratio
   denominator from the RMA Summary-of-Business coverage file (`sob.py`) — the *true* total insured
   liability across all policies — removing the >1 artifact of the Cause-of-Loss loss-experience

--- a/docs/guides/drought-benchmark.md
+++ b/docs/guides/drought-benchmark.md
@@ -61,7 +61,12 @@ years while gradient-boosting and linear models stay strong (0.80–0.95). The p
 - `drought_loss_ratio` uses the **true total insured liability** (RMA Summary-of-Business), removing
   the loss-experience >1 artifact (4 of 13,895 rows marginally exceed 1). Rank metrics and the binary
   target remain robust.
-- v0.2 is corn + Corn Belt; soybean, CONUS, and additional predictors (e.g. GRACE) are planned.
+- **Other crops.** The pipeline is crop-parameterized (`crop:` in the config). A **soybean** benchmark
+  is available via `examples/drought_soybean_6state.yml` (13,895 county-years, 4.8% positive; best
+  temporal ROC-AUC 0.93, spatial LOSO 0.91). Caveat: flashdry NDVI is corn-masked, so for non-corn
+  crops `NDVI_anom_z` is a regional vegetation proxy (weather anomalies + USDM severity are
+  crop-agnostic); a crop-masked NDVI layer is a follow-up.
+- CONUS coverage and additional predictors (e.g. GRACE) are planned.
 
 ## Provenance & citation
 

--- a/examples/drought_soybean_6state.yml
+++ b/examples/drought_soybean_6state.yml
@@ -1,0 +1,32 @@
+# Drought-impact benchmark — soybean, 6-state Corn Belt.
+#
+# Same pipeline as the corn config, with crop: SOYBEANS. RMA Cause of Loss, SOB coverage, and NASS
+# planted acres all key on the commodity name "SOYBEANS". Build/evaluate identically:
+#
+#   terraflow drought fetch    --rma-dir data/drought/rma --sob-dir data/drought/sob
+#   terraflow drought build    -c examples/drought_soybean_6state.yml
+#   terraflow drought evaluate -c examples/drought_soybean_6state.yml
+#
+# CAVEAT: the flashdry NDVI predictor is corn-masked, so for soybean NDVI_anom_z acts as a regional
+# vegetation-stress proxy, not a crop-specific signal. The weather anomalies and USDM severity are
+# crop-agnostic. A soybean-masked NDVI layer is a planned follow-up.
+
+states: ["17", "18", "19", "27", "29", "31"]   # IL IN IA MN MO NE
+crop: "SOYBEANS"
+year_min: 2000
+year_max: 2023
+
+drought_causes: ["Drought"]
+loss_ratio_threshold: 0.10
+cutoff_doy: 212
+
+test_years: [2012, 2017, 2022, 2023]
+train_max_year: 2015
+n_blocks_side: 4
+
+rma_dir: "data/drought/rma"
+sob_dir: "data/drought/sob"
+add_coverage: true
+
+feature_table: "PATH/TO/flashdry/data/processed/feature_table.parquet"
+output_dir: "outputs/drought_soybean"

--- a/tests/test_drought_pipeline.py
+++ b/tests/test_drought_pipeline.py
@@ -174,3 +174,67 @@ def test_run_leaderboard_empty_split_raises(tmp_path: Path):
     )
     with pytest.raises(ValueError, match="empty train or test"):
         run_leaderboard(bench, cfg)
+
+
+def test_assemble_is_crop_parameterized(tmp_path: Path):
+    # Build a soybean benchmark from synthetic data: only SOYBEANS rows are scored.
+    ft = make_feature_table(_GEOIDS, [2000, 2001])
+    ft_path = tmp_path / "feature_table.parquet"
+    ft.to_parquet(ft_path, index=False)
+    for y in (2000, 2001):
+        write_synthetic_col(
+            tmp_path / f"colsom_{y}.zip",
+            [
+                {
+                    "year": y,
+                    "state": g[:2],
+                    "county": g[2:],
+                    "commodity": "SOYBEANS",
+                    "cause": "Drought",
+                    "liability": 1000,
+                    "indemnity": 300,
+                }
+                for g in _GEOIDS
+            ]
+            + [
+                {
+                    "year": y,
+                    "state": _GEOIDS[0][:2],
+                    "county": _GEOIDS[0][2:],
+                    "commodity": "CORN",
+                    "cause": "Drought",
+                    "liability": 1000,
+                    "indemnity": 999,
+                }
+                for _ in (0,)
+            ],
+        )
+        write_synthetic_sob(
+            tmp_path / f"sobcov_{y}.zip",
+            [
+                {
+                    "year": y,
+                    "state": g[:2],
+                    "county": g[2:],
+                    "commodity": "SOYBEANS",
+                    "liability": 100000,
+                    "acres": 5000,
+                }
+                for g in _GEOIDS
+            ],
+        )
+    cfg = DroughtConfig(
+        crop="SOYBEANS",
+        states=_STATES,
+        year_min=2000,
+        year_max=2001,
+        rma_dir=tmp_path,
+        sob_dir=tmp_path,
+        feature_table=ft_path,
+        output_dir=tmp_path / "out",
+        add_coverage=False,
+    )
+    bench = assemble_benchmark(cfg, write=True)
+    # The corn indemnity (999) must be excluded; soybean drought_indemnity is 300 per county-year.
+    assert bench["drought_indemnity"].max() == 300.0
+    assert (cfg.output_dir / "benchmark.parquet").exists()

--- a/tests/test_drought_pipeline.py
+++ b/tests/test_drought_pipeline.py
@@ -236,5 +236,5 @@ def test_assemble_is_crop_parameterized(tmp_path: Path):
     )
     bench = assemble_benchmark(cfg, write=True)
     # The corn indemnity (999) must be excluded; soybean drought_indemnity is 300 per county-year.
-    assert bench["drought_indemnity"].max() == 300.0
+    assert bench["drought_indemnity"].max() == pytest.approx(300.0)
     assert (cfg.output_dir / "benchmark.parquet").exists()


### PR DESCRIPTION
Closes #167.

The `terraflow.drought` pipeline was already crop-parameterized — RMA Cause of Loss, the SOB coverage file, and NASS planted acres all key on the commodity name (verified: all three use `SOYBEANS`). So soybean support is a config + docs + test, no core change.

## Real soybean leaderboard
13,895 county-years, 587 counties, **4.8% positive** (rarer than corn's 6%). Temporal split (test = 2012/17/22/23):

| Model | ROC-AUC | PR-AUC |
|---|---|---|
| GradientBoost[climate] | **0.93** | 0.37 |
| LogReg[climate] | 0.87 | 0.38 |
| Spatial LOSO RF[climate] | 0.91 | 0.42 |

## Caveat (documented)
flashdry's NDVI is **corn-masked**, so for soybean `NDVI_anom_z` is a regional vegetation-stress proxy, not a crop-specific signal. The 30 weather anomalies and USDM severity are crop-agnostic. A soybean-masked NDVI layer is a follow-up.

## Changes
`examples/drought_soybean_6state.yml`, a crop-parameterization test, docs-guide note, CHANGELOG. Full drought suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
