### PR TITLE
fix(drought): correct benchmark datasheet + Zenodo metadata

### DIFF
--- a/data/drought/DATASHEET.md
+++ b/data/drought/DATASHEET.md
@@ -11,14 +11,14 @@ Following Gebru et al., *Datasheets for Datasets* (2021).
 
 ## Composition
 
-- **Instances.** One row per (county `GEOID`, corn crop-year). v0 = corn, 6-state Corn Belt
-  (IL/IN/IA/MN/MO/NE), 2000–2023. **13,895 rows, 587 counties.**
+- **Instances.** One row per (county `GEOID`, crop, crop-year). v0 covers **corn** and **soybean**,
+  6-state Corn Belt (IL/IN/IA/MN/MO/NE), 2000–2023. **13,895 rows, 587 counties per crop.**
 - **Features.** 30 deseasonalized flashdry climate anomalies (`*_anom`) + `NDVI_anom_z` + USDM
   severity (`dm_gte_d2`, `dm_class`), each aggregated {mean, min, max, last} up to `cutoff_doy`
   (default ≈ Jul 31 — early-warning), plus `n_obs` and `n_stress_weeks`.
 - **Labels.** `drought_loss_ratio` (regression; drought indemnity / true insured liability),
-  `significant_drought_loss` (binary, positive rate **6.0%**), `drought_share` (bounded auxiliary),
-  and raw `drought_indemnity` / `total_indemnity` / `total_liability`.
+  `significant_drought_loss` (binary, positive rate **6.0% corn / 4.8% soybean**), `drought_share`
+  (bounded auxiliary), and raw `drought_indemnity` / `total_indemnity` / `total_liability`.
 - **Coverage.** `insured_acres`, `total_premium`, `planted_acres`, and `insured_acre_fraction`
   (insured / planted acres; median ≈ 0.70) expose RMA's insured-only coverage bias.
 - **Splits** (`splits.json`). Temporal (train ≤ 2015, test = 2012/2017/2022/2023), leave-one-state-out
@@ -44,10 +44,14 @@ leaderboard (`leaderboard.csv`) covers naive, severity-only, and Ridge/RF/GBM cl
 - **Denominator.** `drought_loss_ratio` uses the **true total insured liability** (RMA
   Summary-of-Business), so the loss-experience >1 artifact is essentially removed (4 of 13,895
   rows marginally exceed 1). Rank metrics and the binary target remain robust.
-- **Scope.** v0 is corn + Corn Belt; soybean, CONUS, and additional predictors (e.g. GRACE) are future work.
+- **Soybean NDVI.** The flashdry NDVI layer is corn-masked, so for soybean `NDVI_anom_z` is a
+  regional vegetation-stress proxy (weather anomalies and USDM severity are crop-agnostic); a
+  soybean-masked NDVI layer is a planned follow-up.
+- **Scope.** v0 is corn + soybean over the Corn Belt; CONUS and additional predictors (e.g. GRACE) are future work.
 
 ## Distribution & license
 
 - Benchmark table + splits + manifest + leaderboard are released on Zenodo:
-  **DOI [10.5281/zenodo.21208651](https://doi.org/10.5281/zenodo.21208651)** (concept DOI — always latest version). Code: MIT (`terraflow`). Upstream data are public/open; cite the flashdry
-  corpus and the upstream products.
+  **DOI [10.5281/zenodo.21208651](https://doi.org/10.5281/zenodo.21208651)** (concept DOI — always
+  resolves to the latest version). Code: MIT (`terraflow`). Upstream data are public/open; cite the
+  flashdry corpus and the upstream products.

--- a/data/drought/zenodo-benchmark.json
+++ b/data/drought/zenodo-benchmark.json
@@ -1,6 +1,6 @@
 {
   "//": "Metadata for the MANUAL Zenodo dataset deposit of the drought-impact benchmark. Upload the bundled artifacts (corn/ + soybean/ each with benchmark.parquet, splits.json, manifest.json, leaderboard.csv, evaluate_report.json, plus DATASHEET.md) as a NEW VERSION of the existing record and paste these fields.",
-  "//doi": "This is the CONCEPT DOI (shown under 'Cite all versions of this record') — always cite this in the ESSD manuscript. Confirmed 2026-07-06: concept DOI = 10.5281/zenodo.21208651; the v0.3 version-specific DOI is 10.5281/zenodo.21211975 (do NOT cite version DOIs). Publishing a new version mints a new version DOI automatically while the concept DOI stays the same.",
+  "//doi": "This 'doi' field is the CONCEPT DOI (shown under 'Cite all versions of this record'), which always resolves to the latest version. Confirmed 2026-07-06: concept DOI = 10.5281/zenodo.21208651; the v0.3 version-specific DOI is 10.5281/zenodo.21211975. Publishing a new version mints a new version DOI while the concept DOI stays constant. For a fixed release, cite the VERSION-SPECIFIC DOI of v0.4 in the ESSD manuscript (exact reproducibility per Zenodo's versioning guidance); the concept DOI is used here in the living datasheet so it tracks the latest release.",
   "doi": "10.5281/zenodo.21208651",
   "version": "v0.4",
   "title": "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for corn and soybean in the US Corn Belt",

--- a/data/drought/zenodo-benchmark.json
+++ b/data/drought/zenodo-benchmark.json
@@ -1,17 +1,18 @@
 {
-  "//": "Metadata for the MANUAL Zenodo dataset deposit of the drought-impact benchmark. This is NOT the flashdry GitHub-release integration; upload the bundled artifacts (benchmark.parquet, splits.json, manifest.json, leaderboard.csv, evaluate_report.json, DATASHEET.md) as a new Zenodo record and paste these fields.",
+  "//": "Metadata for the MANUAL Zenodo dataset deposit of the drought-impact benchmark. Upload the bundled artifacts (corn/ + soybean/ each with benchmark.parquet, splits.json, manifest.json, leaderboard.csv, evaluate_report.json, plus DATASHEET.md) as a NEW VERSION of the existing record and paste these fields.",
+  "//doi": "This is the CONCEPT DOI (shown under 'Cite all versions of this record') — always cite this in the ESSD manuscript. Confirmed 2026-07-06: concept DOI = 10.5281/zenodo.21208651; the v0.3 version-specific DOI is 10.5281/zenodo.21211975 (do NOT cite version DOIs). Publishing a new version mints a new version DOI automatically while the concept DOI stays the same.",
   "doi": "10.5281/zenodo.21208651",
-  "version": "v0.3",
-  "title": "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for the US Corn Belt",
+  "version": "v0.4",
+  "title": "Drought-Impact Prediction Benchmark (v0): county-level insured drought loss for corn and soybean in the US Corn Belt",
   "upload_type": "dataset",
-  "description": "A prediction-ready, impact-labeled drought benchmark: predict realized insured drought loss (USDA RMA Cause of Loss) from within-season climate/vegetation anomalies. v0 covers corn across the 6-state US Corn Belt (IL/IN/IA/MN/MO/NE), 2000-2023 (13,895 county-years, 587 counties, 18.5% positive). Distinct from drought-severity (USDM) and crop-yield benchmarks. Includes official temporal / leave-one-state-out spatial / leave-one-year-out splits and a baseline leaderboard. Built and reproducible with the open-source terraflow.drought pipeline.",
+  "description": "A prediction-ready, impact-labeled drought benchmark: predict realized insured drought loss (USDA RMA Cause of Loss) from within-season climate/vegetation anomalies. v0 covers corn and soybean across the 6-state US Corn Belt (IL/IN/IA/MN/MO/NE), 2000-2023 (13,895 county-years and 587 counties per crop; positive rate 6.0% for corn, 4.8% for soybean). The drought-loss ratio uses the TRUE total insured liability from the RMA Summary-of-Business coverage files (removing the loss-experience >1 artifact). Distinct from drought-severity (USDM) and crop-yield benchmarks. Includes official temporal / leave-one-state-out spatial / leave-one-year-out splits and a baseline leaderboard (best temporal ROC-AUC 0.95 for corn and 0.93 for soybean; spatial leave-one-state-out 0.91 for corn and 0.90 for soybean). Built and reproducible with the open-source terraflow.drought pipeline; each build carries a deterministic SHA-256 fingerprint in manifest.json.",
   "creators": [
-    {"name": "Marupilla, Gnaneswara", "orcid": "0000-0002-6030-8707"},
+    {"name": "Marupilla, Gnaneswara", "orcid": "0000-0002-6030-8707", "affiliation": "Independent Researcher"},
     {"name": "Bayina, Chandhini", "orcid": "0009-0002-1359-1762", "affiliation": "University of Central Missouri"}
   ],
   "keywords": [
     "drought", "agriculture", "crop insurance", "impact prediction", "benchmark",
-    "remote sensing", "climate", "Corn Belt", "machine learning", "reproducibility"
+    "remote sensing", "climate", "Corn Belt", "corn", "soybean", "machine learning", "reproducibility"
   ],
   "license": "cc-by-4.0",
   "related_identifiers": [
@@ -19,5 +20,5 @@
     {"relation": "isSupplementTo", "identifier": "https://github.com/gmarupilla/AgroTerraFlow", "resource_type": "software"},
     {"relation": "references", "identifier": "https://www.rma.usda.gov/tools-reports/summary-of-business/cause-loss", "resource_type": "dataset"}
   ],
-  "notes": "Predictors derive from the flashdry corpus (MODIS/ERA5-Land/Daymet/USDM/USDA-NASS); labels from public USDA RMA Cause of Loss. See DATASHEET.md for full provenance and limitations."
+  "notes": "Predictors derive from the flashdry corpus (MODIS/ERA5-Land/Daymet/USDM/USDA-NASS); labels from public USDA RMA Cause of Loss and Summary-of-Business coverage files. See DATASHEET.md for full provenance and limitations."
 }


### PR DESCRIPTION
The drought-benchmark datasheet and Zenodo deposit metadata described a stale build (**18.5% positive, corn-only**). The current SOB-hardened pipeline yields **6.0% positive for corn** and **4.8% for soybean**, using the true Summary-of-Business total insured liability as the drought-loss-ratio denominator.

## Changes
- **`data/drought/DATASHEET.md`**
  - Instances/labels now cover **corn + soybean** (13,895 rows, 587 counties per crop)
  - Positive rate corrected to **6.0% corn / 4.8% soybean**
  - Added the soybean corn-masked-NDVI caveat
  - Concept DOI stated as `10.5281/zenodo.21208651`
- **`data/drought/zenodo-benchmark.json`**
  - Bumped to **v0.4**; corn+soybean title / description / keywords
  - Note distinguishing the **concept DOI** (`21208651`) from the v0.3 **version DOI** (`21211975`)

## Verification
Both figures reproduced on a fresh real-data build (`terraflow drought build/evaluate`, no synthetic data): corn `positive_rate 0.0597`, soybean `0.0483`.

Docs-only change to the benchmark datasheet + deposit metadata; no code or pipeline behaviour changes.